### PR TITLE
updated so that it can handle non-Measure line in stats header

### DIFF
--- a/freesurfer_stats/__init__.py
+++ b/freesurfer_stats/__init__.py
@@ -141,15 +141,16 @@ class CorticalParcellationStats:
         self.whole_brain_measurements = pandas.DataFrame()
         line = self._read_header_line(stream)
         while not line.startswith('NTableCols'):
-            key, name, value, unit \
-                = self._GENERAL_MEASUREMENTS_REGEX.match(line).groups()
-            if key == 'SupraTentorialVolNotVent' and name.lower() == 'supratentorial volume':
-                name += ' Without Ventricles'
-            column_name = self._format_column_name(name, unit)
-            assert column_name not in self.whole_brain_measurements, \
-                (key, name, column_name, self.whole_brain_measurements)
-            self.whole_brain_measurements[column_name] \
-                = pandas.to_numeric([value], errors='raise')
+            match = self._GENERAL_MEASUREMENTS_REGEX.match(line)
+            if match:
+                key, name, value, unit = match.groups()
+                if key == 'SupraTentorialVolNotVent' and name.lower() == 'supratentorial volume':
+                    name += ' Without Ventricles'
+                column_name = self._format_column_name(name, unit)
+                assert column_name not in self.whole_brain_measurements, \
+                    (key, name, column_name, self.whole_brain_measurements)
+                self.whole_brain_measurements[column_name] \
+                    = pandas.to_numeric([value], errors='raise')
             line = self._read_header_line(stream)
         columns = self._read_column_attributes(
             int(line[len('NTableCols '):]), stream)

--- a/tests/subjects/soichi/stats/aseg.stats
+++ b/tests/subjects/soichi/stats/aseg.stats
@@ -1,0 +1,124 @@
+# Title Segmentation Statistics 
+# 
+# generating_program mri_segstats
+# cvs_version 7.0.0
+# cmdline mri_segstats --seed 1234 --seg mri/aseg.mgz --sum stats/aseg.stats --pv mri/norm.mgz --empty --brainmask mri/brainmask.mgz --brain-vol-from-seg --excludeid 0 --excl-ctxgmwm --supratent --subcortgray --in mri/norm.mgz --in-intensity-name norm --in-intensity-units MR --etiv --surf-wm-vol --surf-ctx-vol --totalgray --euler --ctab /usr/local/freesurfer/ASegStatsLUT.txt --subject output 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# anatomy_type volume
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# subjectname output
+# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3
+# Measure BrainSeg, BrainSegVol, Brain Segmentation Volume, 1169408.000000, mm^3
+# Measure BrainSegNotVent, BrainSegVolNotVent, Brain Segmentation Volume Without Ventricles, 1157593.000000, mm^3
+# Measure VentricleChoroidVol, VentricleChoroidVol, Volume of ventricles and choroid plexus, 9296.000000, mm^3
+# Measure lhCortex, lhCortexVol, Left hemisphere cortical gray matter volume, 232345.220912, mm^3
+# Measure rhCortex, rhCortexVol, Right hemisphere cortical gray matter volume, 222242.475246, mm^3
+# Measure Cortex, CortexVol, Total cortical gray matter volume, 454587.696158, mm^3
+# Measure lhCerebralWhiteMatter, lhCerebralWhiteMatterVol, Left hemisphere cerebral white matter volume, 251589.500000, mm^3
+# Measure rhCerebralWhiteMatter, rhCerebralWhiteMatterVol, Right hemisphere cerebral white matter volume, 244895.500000, mm^3
+# Measure CerebralWhiteMatter, CerebralWhiteMatterVol, Total cerebral white matter volume, 496485.000000, mm^3
+# Measure SubCortGray, SubCortGrayVol, Subcortical gray matter volume, 62428.000000, mm^3
+# Measure TotalGray, TotalGrayVol, Total gray matter volume, 625759.696158, mm^3
+# Measure SupraTentorial, SupraTentorialVol, Supratentorial volume, 1023873.000000, mm^3
+# Measure SupraTentorialNotVent, SupraTentorialVolNotVent, Supratentorial volume, 1012058.000000, mm^3
+# Measure Mask, MaskVol, Mask Volume, 1686052.000000, mm^3
+# Measure BrainSegVol-to-eTIV, BrainSegVol-to-eTIV, Ratio of BrainSegVol to eTIV, 0.823275, unitless
+# Measure MaskVol-to-eTIV, MaskVol-to-eTIV, Ratio of MaskVol to eTIV, 1.186998, unitless
+# Measure lhSurfaceHoles, lhSurfaceHoles, Number of defect holes in lh surfaces prior to fixing, 24, unitless
+# Measure rhSurfaceHoles, rhSurfaceHoles, Number of defect holes in rh surfaces prior to fixing, 25, unitless
+# Measure SurfaceHoles, SurfaceHoles, Total number of defect holes in surfaces prior to fixing, 49, unitless
+# Measure EstimatedTotalIntraCranialVol, eTIV, Estimated Total Intracranial Volume, 1420434.160521, mm^3
+# SegVolFile mri/aseg.mgz 
+# SegVolFileTimeStamp  2020/05/04 22:14:04 
+# ColorTable /usr/local/freesurfer/ASegStatsLUT.txt 
+# ColorTableTimeStamp 2020/04/29 22:19:19 
+# InVolFile  mri/norm.mgz 
+# InVolFileTimeStamp  2020/05/04 19:28:46 
+# InVolFrame 0 
+# PVVolFile  mri/norm.mgz 
+# PVVolFileTimeStamp  2020/05/04 19:28:46 
+# Excluding Cortical Gray and White Matter
+# ExcludeSegId 0 2 3 41 42 
+# VoxelVolume_mm3 1 
+# TableCol  1 ColHeader Index 
+# TableCol  1 FieldName Index 
+# TableCol  1 Units     NA 
+# TableCol  2 ColHeader SegId 
+# TableCol  2 FieldName Segmentation Id
+# TableCol  2 Units     NA
+# TableCol  3 ColHeader NVoxels 
+# TableCol  3 FieldName Number of Voxels
+# TableCol  3 Units     unitless
+# TableCol  4 ColHeader Volume_mm3
+# TableCol  4 FieldName Volume
+# TableCol  4 Units     mm^3
+# TableCol  5 ColHeader StructName
+# TableCol  5 FieldName Structure Name
+# TableCol  5 Units     NA
+# TableCol  6 ColHeader normMean 
+# TableCol  6 FieldName Intensity normMean
+# TableCol  6 Units     MR
+# TableCol  7 ColHeader normStdDev
+# TableCol  7 FieldName Itensity normStdDev
+# TableCol  7 Units     MR
+# TableCol  8 ColHeader normMin
+# TableCol  8 FieldName Intensity normMin
+# TableCol  8 Units     MR
+# TableCol  9 ColHeader normMax
+# TableCol  9 FieldName Intensity normMax
+# TableCol  9 Units     MR
+# TableCol 10 ColHeader normRange
+# TableCol 10 FieldName Intensity normRange
+# TableCol 10 Units     MR
+# NRows 45 
+# NTableCols 10 
+# ColHeaders  Index SegId NVoxels Volume_mm3 StructName normMean normStdDev normMin normMax normRange  
+  1   4      5077     5581.1  Left-Lateral-Ventricle            27.3055    15.4437     0.0000    88.0000    88.0000 
+  2   5       132      195.5  Left-Inf-Lat-Vent                 53.1970     9.2625    37.0000    76.0000    39.0000 
+  3   7     18074    18350.4  Left-Cerebellum-White-Matter      80.1782     9.0470    36.0000   106.0000    70.0000 
+  4   8     54976    55868.4  Left-Cerebellum-Cortex            48.4004    10.9809     6.0000    98.0000    92.0000 
+  5  10      8612     8178.8  Left-Thalamus                     83.3560    10.4341    27.0000   114.0000    87.0000 
+  6  11      3824     3708.7  Left-Caudate                      70.4786     9.3153    30.0000    99.0000    69.0000 
+  7  12      5776     5622.3  Left-Putamen                      83.7332     7.1692    43.0000   102.0000    59.0000 
+  8  13      2124     2091.0  Left-Pallidum                     97.9812     3.8737    79.0000   110.0000    31.0000 
+  9  14       679      741.0  3rd-Ventricle                     37.1487    15.2063     0.0000    78.0000    78.0000 
+ 10  15       875     1019.4  4th-Ventricle                     31.0811    14.2070     0.0000    76.0000    76.0000 
+ 11  16     21320    21011.7  Brain-Stem                        84.7268    12.0079    25.0000   140.0000   115.0000 
+ 12  17      4357     4333.5  Left-Hippocampus                  65.6167     8.2438    26.0000   108.0000    82.0000 
+ 13  18      1573     1549.1  Left-Amygdala                     64.1742     6.3122    41.0000    83.0000    42.0000 
+ 14  24       965     1007.5  CSF                               41.3772    12.8093     6.0000    68.0000    62.0000 
+ 15  26       731      718.7  Left-Accumbens-area               66.7989     5.7314    42.0000    86.0000    44.0000 
+ 16  28      4324     4125.1  Left-VentralDC                    91.7333    12.2516    31.0000   132.0000   101.0000 
+ 17  30         0        0.0  Left-vessel                        0.0000     0.0000     0.0000     0.0000     0.0000 
+ 18  31       419      356.7  Left-choroid-plexus               51.7375    15.3314    20.0000    80.0000    60.0000 
+ 19  43      3051     3370.2  Right-Lateral-Ventricle           35.5257    16.2240     0.0000    81.0000    81.0000 
+ 20  44       186      270.7  Right-Inf-Lat-Vent                46.6720    11.2473    14.0000    78.0000    64.0000 
+ 21  46     18717    19204.9  Right-Cerebellum-White-Matter     79.0736     9.2274    32.0000   106.0000    74.0000 
+ 22  47     53768    54076.3  Right-Cerebellum-Cortex           47.0445    10.8816    10.0000    92.0000    82.0000 
+ 23  49      7812     7387.3  Right-Thalamus                    80.6749     9.9149    37.0000   103.0000    66.0000 
+ 24  50      3740     3580.3  Right-Caudate                     73.5816     9.0473    37.0000   105.0000    68.0000 
+ 25  51      6114     5882.7  Right-Putamen                     82.4882     7.7199    62.0000   122.0000    60.0000 
+ 26  52      2201     2163.7  Right-Pallidum                    97.5766     3.9017    78.0000   108.0000    30.0000 
+ 27  53      4391     4328.9  Right-Hippocampus                 65.4297     8.8955    25.0000   120.0000    95.0000 
+ 28  54      1715     1665.5  Right-Amygdala                    63.4548     7.4180    31.0000    84.0000    53.0000 
+ 29  58       751      700.3  Right-Accumbens-area              68.9933     6.9871    49.0000    93.0000    44.0000 
+ 30  60      4383     4158.7  Right-VentralDC                   88.2469    12.5069    35.0000   131.0000    96.0000 
+ 31  62         0        0.0  Right-vessel                       0.0000     0.0000     0.0000     0.0000     0.0000 
+ 32  63       431      389.1  Right-choroid-plexus              54.3295    13.1272    26.0000    80.0000    54.0000 
+ 33  72         0        0.0  5th-Ventricle                      0.0000     0.0000     0.0000     0.0000     0.0000 
+ 34  77      2244     1880.1  WM-hypointensities                69.7460    12.6019    33.0000   102.0000    69.0000 
+ 35  78         0        0.0  Left-WM-hypointensities            0.0000     0.0000     0.0000     0.0000     0.0000 
+ 36  79         0        0.0  Right-WM-hypointensities           0.0000     0.0000     0.0000     0.0000     0.0000 
+ 37  80         0        0.0  non-WM-hypointensities             0.0000     0.0000     0.0000     0.0000     0.0000 
+ 38  81         0        0.0  Left-non-WM-hypointensities        0.0000     0.0000     0.0000     0.0000     0.0000 
+ 39  82         0        0.0  Right-non-WM-hypointensities       0.0000     0.0000     0.0000     0.0000     0.0000 
+ 40  85       152      139.0  Optic-Chiasm                      67.6645    10.3527    42.0000   107.0000    65.0000 
+ 41 251      1297     1197.2  CC_Posterior                      98.0948    12.6156    45.0000   113.0000    68.0000 
+ 42 252       707      631.7  CC_Mid_Posterior                  89.1471    17.0599    20.0000   115.0000    95.0000 
+ 43 253       886      789.6  CC_Central                        90.2009    16.9791    24.0000   119.0000    95.0000 
+ 44 254       905      809.6  CC_Mid_Anterior                   93.8497    17.3849    32.0000   127.0000    95.0000 
+ 45 255      1192     1124.7  CC_Anterior                      102.1720    12.2017    47.0000   126.0000    79.0000 

--- a/tests/subjects/soichi/stats/brainvol.stats
+++ b/tests/subjects/soichi/stats/brainvol.stats
@@ -1,0 +1,16 @@
+# Measure BrainSeg, BrainSegVol, Brain Segmentation Volume, 1169408.000000000000, mm^3
+# Measure BrainSegNotVent, BrainSegVolNotVent, Brain Segmentation Volume Without Ventricles, 1157593.000000000000, mm^3
+# Measure SupraTentorial, SupraTentorialVol, Supratentorial volume, 1023873.000000000000, mm^3
+# Measure SupraTentorialNotVent, SupraTentorialVolNotVent, Supratentorial volume, 1012058.000000000000, mm^3
+# Measure SubCortGray, SubCortGrayVol, Subcortical gray matter volume, 62428.000000000000, mm^3
+# Measure lhCortex, lhCortexVol, Left hemisphere cortical gray matter volume, 232345.220911918441, mm^3
+# Measure rhCortex, rhCortexVol, Right hemisphere cortical gray matter volume, 222242.475245694164, mm^3
+# Measure Cortex, CortexVol, Total cortical gray matter volume, 454587.696157612605, mm^3
+# Measure TotalGray, TotalGrayVol, Total gray matter volume, 625759.696157612605, mm^3
+# Measure lhCerebralWhiteMatter, lhCerebralWhiteMatterVol, Left hemisphere cerebral white matter volume, 251589.500000000000, mm^3
+# Measure rhCerebralWhiteMatter, rhCerebralWhiteMatterVol, Right hemisphere cerebral white matter volume, 244895.500000000000, mm^3
+# Measure CerebralWhiteMatter, CerebralWhiteMatterVol, Total cerebral white matter volume, 496485.000000000000, mm^3
+# Measure Mask, MaskVol, Mask Volume, 1686052.000000000000, mm^3
+# Measure SupraTentorialNotVentVox, SupraTentorialVolNotVentVox, Supratentorial volume voxel count, 1012058.000000000000, mm^3
+# Measure BrainSegNotVentSurf, BrainSegVolNotVentSurf, Brain Segmentation Volume Without Ventricles from Surf, 1157593.000000000000, mm^3
+# Measure VentricleChoroidVol, VentricleChoroidVol, Volume of ventricles and choroid plexus, 9296.000000000000, mm^3

--- a/tests/subjects/soichi/stats/lh.BA_exvivo.stats
+++ b/tests/subjects/soichi/stats/lh.BA_exvivo.stats
@@ -1,0 +1,74 @@
+# Table of FreeSurfer cortical parcellation anatomical statistics 
+# 
+# CreationTime 2020/05/04-22:22:50-GMT
+# generating_program mris_anatomical_stats
+# cvs_version 7.0.0
+# mrisurf.c-cvs_version 7.0.0
+# cmdline mris_anatomical_stats -th3 -mgz -f ../stats/lh.BA_exvivo.stats -b -a ./lh.BA_exvivo.annot -c ./BA_exvivo.ctab output lh white 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# anatomy_type surface
+# subjectname output
+# hemi lh
+# AnnotationFile ./lh.BA_exvivo.annot
+# AnnotationFileTimeStamp 2020/05/04 22:22:46
+# Measure Cortex, NumVert, Number of Vertices, 127765, unitless
+# Measure Cortex, WhiteSurfArea, White Surface Total Area, 90204.3, mm^2
+# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3
+# Measure BrainSeg, BrainSegVol, Brain Segmentation Volume, 1169408.000000, mm^3
+# Measure BrainSegNotVent, BrainSegVolNotVent, Brain Segmentation Volume Without Ventricles, 1157593.000000, mm^3
+# Measure BrainSegNotVentSurf, BrainSegVolNotVentSurf, Brain Segmentation Volume Without Ventricles from Surf, 1157593.000000, mm^3
+# Measure Cortex, CortexVol, Total cortical gray matter volume, 454587.696158, mm^3
+# Measure SupraTentorial, SupraTentorialVol, Supratentorial volume, 1023873.000000, mm^3
+# Measure SupraTentorialNotVent, SupraTentorialVolNotVent, Supratentorial volume, 1012058.000000, mm^3
+# Measure EstimatedTotalIntraCranialVol, eTIV, Estimated Total Intracranial Volume, 1420434.160521, mm^3
+# NTableCols 10
+# TableCol  1 ColHeader StructName
+# TableCol  1 FieldName Structure Name
+# TableCol  1 Units     NA
+# TableCol  2 ColHeader NumVert
+# TableCol  2 FieldName Number of Vertices
+# TableCol  2 Units     unitless
+# TableCol  3 ColHeader SurfArea
+# TableCol  3 FieldName Surface Area
+# TableCol  3 Units     mm^2
+# TableCol  4 ColHeader GrayVol
+# TableCol  4 FieldName Gray Matter Volume
+# TableCol  4 Units     mm^3
+# TableCol  5 ColHeader ThickAvg 
+# TableCol  5 FieldName Average Thickness
+# TableCol  5 Units     mm
+# TableCol  6 ColHeader ThickStd
+# TableCol  6 FieldName Thickness StdDev
+# TableCol  6 Units     mm 
+# TableCol  7 ColHeader MeanCurv
+# TableCol  7 FieldName Integrated Rectified Mean Curvature
+# TableCol  7 Units     mm^-1
+# TableCol  8 ColHeader GausCurv 
+# TableCol  8 FieldName Integrated Rectified Gaussian Curvature
+# TableCol  8 Units     mm^-2
+# TableCol  9 ColHeader  FoldInd
+# TableCol  9 FieldName  Folding Index 
+# TableCol  9 Units      unitless 
+# TableCol 10 ColHeader CurvInd
+# TableCol 10 FieldName Intrinsic Curvature Index
+# TableCol 10 Units     unitless
+# ColHeaders StructName NumVert SurfArea GrayVol ThickAvg ThickStd MeanCurv GausCurv FoldInd CurvInd
+BA1_exvivo                               1091    779   2228  2.233 0.587     0.140     0.032       13     1.5
+BA2_exvivo                               3956   2761   6357  2.112 0.581     0.126     0.027       39     4.4
+BA3a_exvivo                              1132    726    973  1.785 0.396     0.129     0.028       10     1.3
+BA3b_exvivo                              2250   1572   3226  1.811 0.557     0.112     0.025       18     2.3
+BA4a_exvivo                              1849   1082   3167  2.671 0.626     0.099     0.022       11     1.7
+BA4p_exvivo                              1313    932   1786  2.033 0.504     0.116     0.026        8     1.5
+BA6_exvivo                              10247   6816  22620  2.873 0.634     0.111     0.023       82     9.7
+BA44_exvivo                              2571   1892   5119  2.394 0.596     0.121     0.024       25     2.8
+BA45_exvivo                              2876   2112   6879  2.597 0.807     0.131     0.033       30     4.0
+V1_exvivo                                3587   2681   4840  1.791 0.478     0.151     0.039       45     5.8
+V2_exvivo                                7987   5971  13181  2.067 0.540     0.155     0.039      108    13.2
+MT_exvivo                                1812   1342   3308  2.268 0.545     0.140     0.032       21     2.5
+perirhinal_exvivo                         572    418   1747  3.036 0.856     0.115     0.031        5     0.8
+entorhinal_exvivo                         544    350   1553  2.938 1.298     0.109     0.032        6     0.7

--- a/tests/subjects/soichi/stats/lh.BA_exvivo.thresh.stats
+++ b/tests/subjects/soichi/stats/lh.BA_exvivo.thresh.stats
@@ -1,0 +1,74 @@
+# Table of FreeSurfer cortical parcellation anatomical statistics 
+# 
+# CreationTime 2020/05/04-22:22:54-GMT
+# generating_program mris_anatomical_stats
+# cvs_version 7.0.0
+# mrisurf.c-cvs_version 7.0.0
+# cmdline mris_anatomical_stats -th3 -mgz -f ../stats/lh.BA_exvivo.thresh.stats -b -a ./lh.BA_exvivo.thresh.annot -c ./BA_exvivo.thresh.ctab output lh white 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# anatomy_type surface
+# subjectname output
+# hemi lh
+# AnnotationFile ./lh.BA_exvivo.thresh.annot
+# AnnotationFileTimeStamp 2020/05/04 22:22:46
+# Measure Cortex, NumVert, Number of Vertices, 127765, unitless
+# Measure Cortex, WhiteSurfArea, White Surface Total Area, 90204.3, mm^2
+# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3
+# Measure BrainSeg, BrainSegVol, Brain Segmentation Volume, 1169408.000000, mm^3
+# Measure BrainSegNotVent, BrainSegVolNotVent, Brain Segmentation Volume Without Ventricles, 1157593.000000, mm^3
+# Measure BrainSegNotVentSurf, BrainSegVolNotVentSurf, Brain Segmentation Volume Without Ventricles from Surf, 1157593.000000, mm^3
+# Measure Cortex, CortexVol, Total cortical gray matter volume, 454587.696158, mm^3
+# Measure SupraTentorial, SupraTentorialVol, Supratentorial volume, 1023873.000000, mm^3
+# Measure SupraTentorialNotVent, SupraTentorialVolNotVent, Supratentorial volume, 1012058.000000, mm^3
+# Measure EstimatedTotalIntraCranialVol, eTIV, Estimated Total Intracranial Volume, 1420434.160521, mm^3
+# NTableCols 10
+# TableCol  1 ColHeader StructName
+# TableCol  1 FieldName Structure Name
+# TableCol  1 Units     NA
+# TableCol  2 ColHeader NumVert
+# TableCol  2 FieldName Number of Vertices
+# TableCol  2 Units     unitless
+# TableCol  3 ColHeader SurfArea
+# TableCol  3 FieldName Surface Area
+# TableCol  3 Units     mm^2
+# TableCol  4 ColHeader GrayVol
+# TableCol  4 FieldName Gray Matter Volume
+# TableCol  4 Units     mm^3
+# TableCol  5 ColHeader ThickAvg 
+# TableCol  5 FieldName Average Thickness
+# TableCol  5 Units     mm
+# TableCol  6 ColHeader ThickStd
+# TableCol  6 FieldName Thickness StdDev
+# TableCol  6 Units     mm 
+# TableCol  7 ColHeader MeanCurv
+# TableCol  7 FieldName Integrated Rectified Mean Curvature
+# TableCol  7 Units     mm^-1
+# TableCol  8 ColHeader GausCurv 
+# TableCol  8 FieldName Integrated Rectified Gaussian Curvature
+# TableCol  8 Units     mm^-2
+# TableCol  9 ColHeader  FoldInd
+# TableCol  9 FieldName  Folding Index 
+# TableCol  9 Units      unitless 
+# TableCol 10 ColHeader CurvInd
+# TableCol 10 FieldName Intrinsic Curvature Index
+# TableCol 10 Units     unitless
+# ColHeaders StructName NumVert SurfArea GrayVol ThickAvg ThickStd MeanCurv GausCurv FoldInd CurvInd
+BA1_exvivo                                715    485   1423  2.282 0.614     0.132     0.029        7     0.8
+BA2_exvivo                               1731   1199   3078  2.154 0.627     0.123     0.026       17     1.9
+BA3a_exvivo                               979    622    789  1.771 0.391     0.131     0.027        9     1.1
+BA3b_exvivo                              1429    963   1633  1.619 0.335     0.090     0.016        7     0.9
+BA4a_exvivo                              1803   1098   2994  2.554 0.655     0.102     0.022       11     1.6
+BA4p_exvivo                              1048    744   1373  2.059 0.481     0.121     0.030        6     1.4
+BA6_exvivo                               5756   3660  12361  2.914 0.616     0.106     0.022       42     5.2
+BA44_exvivo                              1629   1194   3329  2.408 0.587     0.121     0.026       17     1.8
+BA45_exvivo                              1146    896   3419  2.891 0.861     0.149     0.043       16     2.0
+V1_exvivo                                3798   2857   5268  1.803 0.480     0.153     0.040       50     6.4
+V2_exvivo                                3980   3033   6335  1.981 0.519     0.161     0.042       58     7.2
+MT_exvivo                                 503    392    845  2.043 0.515     0.146     0.029        7     0.8
+perirhinal_exvivo                         234    157    525  2.888 0.857     0.077     0.022        1     0.2
+entorhinal_exvivo                         332    210   1129  3.495 0.665     0.063     0.011        1     0.1

--- a/tests/subjects/soichi/stats/lh.aparc.DKTatlas.stats
+++ b/tests/subjects/soichi/stats/lh.aparc.DKTatlas.stats
@@ -1,0 +1,92 @@
+# Table of FreeSurfer cortical parcellation anatomical statistics 
+# 
+# CreationTime 2020/05/04-22:20:53-GMT
+# generating_program mris_anatomical_stats
+# cvs_version 7.0.0
+# mrisurf.c-cvs_version 7.0.0
+# cmdline mris_anatomical_stats -th3 -mgz -cortex ../label/lh.cortex.label -f ../stats/lh.aparc.DKTatlas.stats -b -a ../label/lh.aparc.DKTatlas.annot -c ../label/aparc.annot.DKTatlas.ctab output lh white 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# anatomy_type surface
+# subjectname output
+# hemi lh
+# AnnotationFile ../label/lh.aparc.DKTatlas.annot
+# AnnotationFileTimeStamp 2020/05/04 22:13:39
+# Measure Cortex, NumVert, Number of Vertices, 118968, unitless
+# Measure Cortex, WhiteSurfArea, White Surface Total Area, 84858.5, mm^2
+# Measure Cortex, MeanThickness, Mean Thickness, 2.39891, mm
+# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3
+# Measure BrainSeg, BrainSegVol, Brain Segmentation Volume, 1169408.000000, mm^3
+# Measure BrainSegNotVent, BrainSegVolNotVent, Brain Segmentation Volume Without Ventricles, 1157593.000000, mm^3
+# Measure BrainSegNotVentSurf, BrainSegVolNotVentSurf, Brain Segmentation Volume Without Ventricles from Surf, 1157593.000000, mm^3
+# Measure Cortex, CortexVol, Total cortical gray matter volume, 454587.696158, mm^3
+# Measure SupraTentorial, SupraTentorialVol, Supratentorial volume, 1023873.000000, mm^3
+# Measure SupraTentorialNotVent, SupraTentorialVolNotVent, Supratentorial volume, 1012058.000000, mm^3
+# Measure EstimatedTotalIntraCranialVol, eTIV, Estimated Total Intracranial Volume, 1420434.160521, mm^3
+# NTableCols 10
+# TableCol  1 ColHeader StructName
+# TableCol  1 FieldName Structure Name
+# TableCol  1 Units     NA
+# TableCol  2 ColHeader NumVert
+# TableCol  2 FieldName Number of Vertices
+# TableCol  2 Units     unitless
+# TableCol  3 ColHeader SurfArea
+# TableCol  3 FieldName Surface Area
+# TableCol  3 Units     mm^2
+# TableCol  4 ColHeader GrayVol
+# TableCol  4 FieldName Gray Matter Volume
+# TableCol  4 Units     mm^3
+# TableCol  5 ColHeader ThickAvg 
+# TableCol  5 FieldName Average Thickness
+# TableCol  5 Units     mm
+# TableCol  6 ColHeader ThickStd
+# TableCol  6 FieldName Thickness StdDev
+# TableCol  6 Units     mm 
+# TableCol  7 ColHeader MeanCurv
+# TableCol  7 FieldName Integrated Rectified Mean Curvature
+# TableCol  7 Units     mm^-1
+# TableCol  8 ColHeader GausCurv 
+# TableCol  8 FieldName Integrated Rectified Gaussian Curvature
+# TableCol  8 Units     mm^-2
+# TableCol  9 ColHeader  FoldInd
+# TableCol  9 FieldName  Folding Index 
+# TableCol  9 Units      unitless 
+# TableCol 10 ColHeader CurvInd
+# TableCol 10 FieldName Intrinsic Curvature Index
+# TableCol 10 Units     unitless
+# ColHeaders StructName NumVert SurfArea GrayVol ThickAvg ThickStd MeanCurv GausCurv FoldInd CurvInd
+caudalanteriorcingulate                  1913   1239   3603  2.467 0.703     0.115     0.017       16     1.3
+caudalmiddlefrontal                      3919   2699   7488  2.496 0.570     0.114     0.022       31     3.6
+cuneus                                   3305   2371   4814  1.980 0.503     0.137     0.030       37     4.2
+entorhinal                                508    320   1421  3.022 0.865     0.079     0.018        2     0.3
+fusiform                                 3482   2583   6723  2.345 0.635     0.145     0.036       44     5.4
+inferiorparietal                         5860   4275  11468  2.368 0.575     0.135     0.030       62     7.5
+inferiortemporal                         3641   2785   8483  2.357 0.773     0.142     0.037       49     6.0
+isthmuscingulate                         1531   1046   2524  2.232 0.606     0.128     0.029       17     2.0
+lateraloccipital                         7076   5131  11714  2.097 0.545     0.145     0.035       86    10.6
+lateralorbitofrontal                     3893   2821   9107  2.833 0.824     0.139     0.039       51     6.6
+lingual                                  4323   3349   7887  2.156 0.590     0.157     0.042       59     7.6
+medialorbitofrontal                      2379   1656   5771  2.765 0.957     0.115     0.031       25     3.1
+middletemporal                           4629   3479   8935  2.105 0.644     0.135     0.035       55     6.9
+parahippocampal                           852    543   1868  2.887 0.823     0.091     0.020        5     0.6
+paracentral                              2855   1759   5288  2.739 0.600     0.098     0.020       17     2.3
+parsopercularis                          2322   1661   4742  2.547 0.600     0.118     0.025       21     2.4
+parsorbitalis                            1035    709   2200  2.608 0.616     0.113     0.027        8     1.1
+parstriangularis                         2403   1731   5599  2.663 0.795     0.126     0.029       23     3.0
+pericalcarine                            2055   1502   2258  1.689 0.367     0.147     0.036       25     3.2
+postcentral                              7197   4984  11417  2.064 0.617     0.123     0.027       68     8.3
+posteriorcingulate                       2075   1381   3661  2.363 0.689     0.125     0.025       22     2.2
+precentral                               7814   5201  13250  2.396 0.634     0.116     0.025       64     8.6
+precuneus                                4726   3356   8727  2.345 0.536     0.125     0.027       47     5.0
+rostralanteriorcingulate                 1884   1351   3455  2.252 0.736     0.139     0.039       27     3.3
+rostralmiddlefrontal                     5163   3950  11914  2.420 0.696     0.150     0.044       69     9.9
+superiorfrontal                         11464   8188  28745  2.914 0.726     0.127     0.031      108    14.7
+superiorparietal                         5153   3626   8404  2.165 0.512     0.126     0.026       51     5.5
+superiortemporal                         7014   4942  14435  2.457 0.688     0.117     0.026       64     8.2
+supramarginal                            4962   3772   9689  2.178 0.601     0.144     0.035       66     7.7
+transversetemporal                        788    562   1626  2.337 0.591     0.139     0.047       10     1.8
+insula                                   2747   1886   5438  2.826 0.692     0.116     0.027       21     2.9

--- a/tests/subjects/soichi/stats/lh.aparc.a2009s.stats
+++ b/tests/subjects/soichi/stats/lh.aparc.a2009s.stats
@@ -1,0 +1,135 @@
+# Table of FreeSurfer cortical parcellation anatomical statistics 
+# 
+# CreationTime 2020/05/04-22:20:40-GMT
+# generating_program mris_anatomical_stats
+# cvs_version 7.0.0
+# mrisurf.c-cvs_version 7.0.0
+# cmdline mris_anatomical_stats -th3 -mgz -cortex ../label/lh.cortex.label -f ../stats/lh.aparc.a2009s.stats -b -a ../label/lh.aparc.a2009s.annot -c ../label/aparc.annot.a2009s.ctab output lh white 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# anatomy_type surface
+# subjectname output
+# hemi lh
+# AnnotationFile ../label/lh.aparc.a2009s.annot
+# AnnotationFileTimeStamp 2020/05/04 22:13:27
+# Measure Cortex, NumVert, Number of Vertices, 118968, unitless
+# Measure Cortex, WhiteSurfArea, White Surface Total Area, 84858.5, mm^2
+# Measure Cortex, MeanThickness, Mean Thickness, 2.39891, mm
+# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3
+# Measure BrainSeg, BrainSegVol, Brain Segmentation Volume, 1169408.000000, mm^3
+# Measure BrainSegNotVent, BrainSegVolNotVent, Brain Segmentation Volume Without Ventricles, 1157593.000000, mm^3
+# Measure BrainSegNotVentSurf, BrainSegVolNotVentSurf, Brain Segmentation Volume Without Ventricles from Surf, 1157593.000000, mm^3
+# Measure Cortex, CortexVol, Total cortical gray matter volume, 454587.696158, mm^3
+# Measure SupraTentorial, SupraTentorialVol, Supratentorial volume, 1023873.000000, mm^3
+# Measure SupraTentorialNotVent, SupraTentorialVolNotVent, Supratentorial volume, 1012058.000000, mm^3
+# Measure EstimatedTotalIntraCranialVol, eTIV, Estimated Total Intracranial Volume, 1420434.160521, mm^3
+# NTableCols 10
+# TableCol  1 ColHeader StructName
+# TableCol  1 FieldName Structure Name
+# TableCol  1 Units     NA
+# TableCol  2 ColHeader NumVert
+# TableCol  2 FieldName Number of Vertices
+# TableCol  2 Units     unitless
+# TableCol  3 ColHeader SurfArea
+# TableCol  3 FieldName Surface Area
+# TableCol  3 Units     mm^2
+# TableCol  4 ColHeader GrayVol
+# TableCol  4 FieldName Gray Matter Volume
+# TableCol  4 Units     mm^3
+# TableCol  5 ColHeader ThickAvg 
+# TableCol  5 FieldName Average Thickness
+# TableCol  5 Units     mm
+# TableCol  6 ColHeader ThickStd
+# TableCol  6 FieldName Thickness StdDev
+# TableCol  6 Units     mm 
+# TableCol  7 ColHeader MeanCurv
+# TableCol  7 FieldName Integrated Rectified Mean Curvature
+# TableCol  7 Units     mm^-1
+# TableCol  8 ColHeader GausCurv 
+# TableCol  8 FieldName Integrated Rectified Gaussian Curvature
+# TableCol  8 Units     mm^-2
+# TableCol  9 ColHeader  FoldInd
+# TableCol  9 FieldName  Folding Index 
+# TableCol  9 Units      unitless 
+# TableCol 10 ColHeader CurvInd
+# TableCol 10 FieldName Intrinsic Curvature Index
+# TableCol 10 Units     unitless
+# ColHeaders StructName NumVert SurfArea GrayVol ThickAvg ThickStd MeanCurv GausCurv FoldInd CurvInd
+G_and_S_frontomargin                      938    721   2753  3.043 0.902     0.155     0.049       13     1.6
+G_and_S_occipital_inf                    1521   1161   3032  2.297 0.544     0.147     0.032       19     2.1
+G_and_S_paracentral                      1819   1111   3167  2.483 0.627     0.102     0.021       13     1.5
+G_and_S_subcentral                       1560   1189   3029  2.259 0.591     0.146     0.034       19     2.4
+G_and_S_transv_frontopol                  697    581   2663  3.084 0.849     0.193     0.061       13     1.9
+G_and_S_cingul-Ant                       2242   1586   4187  2.381 0.694     0.124     0.031       22     3.0
+G_and_S_cingul-Mid-Ant                   1426    934   2344  2.515 0.745     0.103     0.014        9     0.8
+G_and_S_cingul-Mid-Post                  1431    940   2497  2.486 0.622     0.109     0.022       12     1.4
+G_cingul-Post-dorsal                      561    405   1498  2.797 0.658     0.153     0.041        8     0.9
+G_cingul-Post-ventral                     317    216    734  2.549 0.661     0.120     0.026        4     0.4
+G_cuneus                                 2292   1701   3582  1.872 0.451     0.155     0.037       29     3.8
+G_front_inf-Opercular                    1255    974   3278  2.579 0.625     0.139     0.035       18     1.8
+G_front_inf-Orbital                       472    333   1358  2.755 0.619     0.145     0.040        6     0.9
+G_front_inf-Triangul                     1161    909   3632  3.013 0.778     0.150     0.039       16     1.9
+G_front_middle                           4081   3199  11487  2.588 0.687     0.157     0.043       63     7.8
+G_front_sup                              7937   5531  22110  3.060 0.703     0.127     0.030       76    10.1
+G_Ins_lg_and_S_cent_ins                   662    480   1396  2.928 0.855     0.135     0.033        8     0.9
+G_insular_short                           669    476   2039  3.162 0.869     0.136     0.041        7     1.1
+G_occipital_middle                       1857   1419   4488  2.490 0.509     0.161     0.042       27     3.4
+G_occipital_sup                          1183    881   2029  1.974 0.482     0.153     0.035       17     1.7
+G_oc-temp_lat-fusifor                    1368   1052   3428  2.581 0.658     0.160     0.046       21     2.7
+G_oc-temp_med-Lingual                    2796   2216   5713  2.207 0.663     0.172     0.050       47     5.9
+G_oc-temp_med-Parahip                    1073    678   2803  2.998 0.860     0.096     0.023        7     0.8
+G_orbital                                2234   1760   6277  2.728 0.684     0.166     0.051       42     5.3
+G_pariet_inf-Angular                     2139   1674   5707  2.581 0.612     0.156     0.038       31     3.5
+G_pariet_inf-Supramar                    2825   2258   6716  2.243 0.694     0.160     0.042       48     5.5
+G_parietal_sup                           2235   1657   4450  2.282 0.557     0.147     0.032       30     3.0
+G_postcentral                            2512   1776   4778  2.161 0.660     0.138     0.032       29     3.5
+G_precentral                             2966   1876   6162  2.628 0.670     0.113     0.027       25     3.3
+G_precuneus                              2103   1556   5141  2.494 0.589     0.146     0.035       29     2.9
+G_rectus                                  941    693   2466  2.614 0.722     0.139     0.038       15     1.6
+G_subcallosal                             877    582   1530  2.534 0.836     0.127     0.048       10     1.7
+G_temp_sup-G_T_transv                     690    492   1620  2.397 0.629     0.154     0.054       10     1.8
+G_temp_sup-Lateral                       1823   1404   5045  2.597 0.729     0.149     0.038       26     3.1
+G_temp_sup-Plan_polar                     874    582   1791  2.649 0.695     0.073     0.012        2     0.5
+G_temp_sup-Plan_tempo                     762    557   1401  2.168 0.622     0.113     0.032        8     1.2
+G_temporal_inf                           1798   1449   4678  2.383 0.752     0.157     0.045       30     3.7
+G_temporal_middle                        1961   1600   5158  2.247 0.720     0.157     0.049       33     4.2
+Lat_Fis-ant-Horizont                      348    226    457  2.309 0.391     0.076     0.011        2     0.1
+Lat_Fis-ant-Vertical                      384    250    494  2.274 0.592     0.097     0.021        2     0.3
+Lat_Fis-post                             1147    772   1352  2.229 0.415     0.117     0.023        8     1.2
+Pole_occipital                           1824   1364   2907  1.927 0.510     0.149     0.040       25     2.9
+Pole_temporal                            1554   1236   5094  2.721 0.865     0.150     0.037       23     2.7
+S_calcarine                              2776   2018   3383  1.881 0.470     0.133     0.032       27     3.6
+S_central                                3209   2141   3334  1.823 0.437     0.111     0.023       21     3.1
+S_cingul-Marginalis                      1179    776   1716  2.411 0.545     0.103     0.017        7     0.7
+S_circular_insula_ant                     549    361    742  2.638 0.564     0.101     0.018        2     0.5
+S_circular_insula_inf                    1325    854   1792  2.531 0.559     0.085     0.015        5     0.8
+S_circular_insula_sup                    1722   1146   2722  2.793 0.527     0.108     0.021        9     1.6
+S_collat_transv_ant                       882    635   1533  2.382 0.690     0.132     0.028       11     1.2
+S_collat_transv_post                      526    366    570  1.949 0.355     0.153     0.035        6     0.8
+S_front_inf                              2376   1606   3538  2.285 0.589     0.108     0.023       15     2.1
+S_front_middle                           1266    876   1878  2.299 0.701     0.117     0.030        9     1.5
+S_front_sup                              2988   2055   4995  2.501 0.508     0.099     0.023       16     2.7
+S_interm_prim-Jensen                      341    231    412  2.065 0.486     0.141     0.036        3     0.5
+S_intrapariet_and_P_trans                2417   1640   3220  2.146 0.480     0.107     0.020       16     2.0
+S_oc_middle_and_Lunatus                  1244    851   1419  1.969 0.460     0.131     0.030       10     1.6
+S_oc_sup_and_transversal                 1388    931   1657  1.924 0.396     0.117     0.021       10     1.3
+S_occipital_ant                           667    448    735  1.990 0.342     0.122     0.027        6     0.7
+S_oc-temp_lat                             586    387    765  2.177 0.470     0.121     0.026        4     0.7
+S_oc-temp_med_and_Lingual                2043   1443   2810  2.084 0.551     0.121     0.025       17     2.0
+S_orbital_lateral                         241    161    271  1.891 0.354     0.105     0.013        1     0.1
+S_orbital_med-olfact                      640    420    835  2.487 0.802     0.099     0.016        4     0.4
+S_orbital-H_Shaped                       1227    836   2452  2.883 0.874     0.121     0.031       11     1.8
+S_parieto_occipital                      2426   1655   3367  2.265 0.509     0.106     0.020       17     2.0
+S_pericallosal                           1373    897   1341  1.876 0.477     0.141     0.024       21     1.4
+S_postcentral                            2934   2003   3886  2.004 0.472     0.117     0.023       25     2.8
+S_precentral-inf-part                    1991   1337   3066  2.405 0.543     0.099     0.017       12     1.5
+S_precentral-sup-part                    1470    989   2153  2.419 0.477     0.104     0.018        9     1.1
+S_suborbital                              713    455   1700  3.106 1.137     0.083     0.012        3     0.3
+S_subparietal                             855    579   1150  2.107 0.416     0.126     0.026        7     0.9
+S_temporal_inf                           1257    840   1450  1.885 0.601     0.109     0.021        7     1.0
+S_temporal_sup                           4611   3181   6805  2.206 0.530     0.113     0.023       33     4.2
+S_temporal_transverse                     431    281    485  2.060 0.424     0.089     0.010        2     0.2

--- a/tests/subjects/soichi/stats/lh.aparc.pial.stats
+++ b/tests/subjects/soichi/stats/lh.aparc.pial.stats
@@ -1,0 +1,95 @@
+# Table of FreeSurfer cortical parcellation anatomical statistics 
+# 
+# CreationTime 2020/05/04-22:20:27-GMT
+# generating_program mris_anatomical_stats
+# cvs_version 7.0.0
+# mrisurf.c-cvs_version 7.0.0
+# cmdline mris_anatomical_stats -th3 -mgz -cortex ../label/lh.cortex.label -f ../stats/lh.aparc.pial.stats -b -a ../label/lh.aparc.annot -c ../label/aparc.annot.ctab output lh pial 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# anatomy_type surface
+# subjectname output
+# hemi lh
+# AnnotationFile ../label/lh.aparc.annot
+# AnnotationFileTimeStamp 2020/05/04 21:58:14
+# Measure Cortex, NumVert, Number of Vertices, 118968, unitless
+# Measure Cortex, PialSurfArea, Pial Surface Total Area, 109814, mm^2
+# Measure Cortex, MeanThickness, Mean Thickness, 2.39891, mm
+# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3
+# Measure BrainSeg, BrainSegVol, Brain Segmentation Volume, 1169408.000000, mm^3
+# Measure BrainSegNotVent, BrainSegVolNotVent, Brain Segmentation Volume Without Ventricles, 1157593.000000, mm^3
+# Measure BrainSegNotVentSurf, BrainSegVolNotVentSurf, Brain Segmentation Volume Without Ventricles from Surf, 1157593.000000, mm^3
+# Measure Cortex, CortexVol, Total cortical gray matter volume, 454587.696158, mm^3
+# Measure SupraTentorial, SupraTentorialVol, Supratentorial volume, 1023873.000000, mm^3
+# Measure SupraTentorialNotVent, SupraTentorialVolNotVent, Supratentorial volume, 1012058.000000, mm^3
+# Measure EstimatedTotalIntraCranialVol, eTIV, Estimated Total Intracranial Volume, 1420434.160521, mm^3
+# NTableCols 10
+# TableCol  1 ColHeader StructName
+# TableCol  1 FieldName Structure Name
+# TableCol  1 Units     NA
+# TableCol  2 ColHeader NumVert
+# TableCol  2 FieldName Number of Vertices
+# TableCol  2 Units     unitless
+# TableCol  3 ColHeader SurfArea
+# TableCol  3 FieldName Surface Area
+# TableCol  3 Units     mm^2
+# TableCol  4 ColHeader GrayVol
+# TableCol  4 FieldName Gray Matter Volume
+# TableCol  4 Units     mm^3
+# TableCol  5 ColHeader ThickAvg 
+# TableCol  5 FieldName Average Thickness
+# TableCol  5 Units     mm
+# TableCol  6 ColHeader ThickStd
+# TableCol  6 FieldName Thickness StdDev
+# TableCol  6 Units     mm 
+# TableCol  7 ColHeader MeanCurv
+# TableCol  7 FieldName Integrated Rectified Mean Curvature
+# TableCol  7 Units     mm^-1
+# TableCol  8 ColHeader GausCurv 
+# TableCol  8 FieldName Integrated Rectified Gaussian Curvature
+# TableCol  8 Units     mm^-2
+# TableCol  9 ColHeader  FoldInd
+# TableCol  9 FieldName  Folding Index 
+# TableCol  9 Units      unitless 
+# TableCol 10 ColHeader CurvInd
+# TableCol 10 FieldName Intrinsic Curvature Index
+# TableCol 10 Units     unitless
+# ColHeaders StructName NumVert SurfArea GrayVol ThickAvg ThickStd MeanCurv GausCurv FoldInd CurvInd
+bankssts                                 1069    724   1536  2.144 0.501     0.127     0.036       14     1.6
+caudalanteriorcingulate                   861    650   1400  2.356 0.465     0.183     0.051      153     2.3
+caudalmiddlefrontal                      3635   3004   6949  2.492 0.571     0.138     0.033       58     4.9
+cuneus                                   2419   2098   3546  1.954 0.480     0.150     0.039       48     3.7
+entorhinal                                548    747   1673  3.053 0.883     0.292     0.086       19     2.2
+fusiform                                 3637   3637   7582  2.391 0.663     0.178     0.043       74     6.9
+inferiorparietal                         5697   5287  11237  2.366 0.575     0.167     0.040      149    10.2
+inferiortemporal                         3670   3858   7429  2.242 0.732     0.191     0.048       71     7.6
+isthmuscingulate                         1534   1285   2524  2.216 0.610     0.187     0.057       74     3.8
+lateraloccipital                         7117   6300  11787  2.107 0.541     0.153     0.038      268    11.8
+lateralorbitofrontal                     3716   3386   7928  2.754 0.771     0.182     0.051      129     7.9
+lingual                                  4256   4271   7791  2.167 0.591     0.186     0.048      112     8.7
+medialorbitofrontal                      2868   3015   6587  2.698 0.908     0.197     0.053       99     6.8
+middletemporal                           3466   4545   7508  2.136 0.678     0.221     0.050       58     7.8
+parahippocampal                           869    839   1942  2.905 0.822     0.183     0.051       12     2.0
+paracentral                              2463   1803   4322  2.661 0.585     1.561     1.470  29914077     2.6
+parsopercularis                          2485   2248   5018  2.506 0.609     0.165     0.041       38     4.5
+parsorbitalis                             890   1203   2586  2.739 0.631     0.242     0.057       18     2.2
+parstriangularis                         1980   1958   4688  2.743 0.784     0.184     0.048       34     4.3
+pericalcarine                            2096   1362   2311  1.688 0.366     0.139     0.044       73     3.5
+postcentral                              6436   5760  10430  2.050 0.626     0.152     0.036       87     9.7
+posteriorcingulate                       1883   1586   3388  2.369 0.697     0.177     0.055       97     3.9
+precentral                               8010   6061  13626  2.403 0.626     0.118     0.028      108     9.3
+precuneus                                4973   4098   8876  2.349 0.519     0.146     0.039       79     7.8
+rostralanteriorcingulate                 1336   1432   2452  2.138 0.702     0.221     0.061       86     3.7
+rostralmiddlefrontal                     7137   7769  16971  2.507 0.744     0.200     0.048      186    15.3
+superiorfrontal                         11318  10278  27120  2.894 0.733     0.153     0.039      185    17.8
+superiorparietal                         6602   5359  10653  2.128 0.536     0.145     0.035      110     9.4
+superiortemporal                         5500   5099  10626  2.377 0.641     0.171     0.048      118    11.1
+supramarginal                            5498   5489  10599  2.190 0.598     0.182     0.044      105    10.6
+frontalpole                               310    451   1203  3.167 1.032     0.242     0.054        5     0.7
+temporalpole                              717   1082   2427  3.027 0.807     0.247     0.057       16     2.0
+transversetemporal                        757    860   1589  2.368 0.586     0.200     0.054        8     1.8
+insula                                   3215   2269   6352  2.897 0.721     0.173     0.064      199     7.6

--- a/tests/subjects/soichi/stats/lh.aparc.stats
+++ b/tests/subjects/soichi/stats/lh.aparc.stats
@@ -1,0 +1,95 @@
+# Table of FreeSurfer cortical parcellation anatomical statistics 
+# 
+# CreationTime 2020/05/04-22:20:26-GMT
+# generating_program mris_anatomical_stats
+# cvs_version 7.0.0
+# mrisurf.c-cvs_version 7.0.0
+# cmdline mris_anatomical_stats -th3 -mgz -cortex ../label/lh.cortex.label -f ../stats/lh.aparc.stats -b -a ../label/lh.aparc.annot -c ../label/aparc.annot.ctab output lh white 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# anatomy_type surface
+# subjectname output
+# hemi lh
+# AnnotationFile ../label/lh.aparc.annot
+# AnnotationFileTimeStamp 2020/05/04 21:58:14
+# Measure Cortex, NumVert, Number of Vertices, 118968, unitless
+# Measure Cortex, WhiteSurfArea, White Surface Total Area, 84858.5, mm^2
+# Measure Cortex, MeanThickness, Mean Thickness, 2.39891, mm
+# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3
+# Measure BrainSeg, BrainSegVol, Brain Segmentation Volume, 1169408.000000, mm^3
+# Measure BrainSegNotVent, BrainSegVolNotVent, Brain Segmentation Volume Without Ventricles, 1157593.000000, mm^3
+# Measure BrainSegNotVentSurf, BrainSegVolNotVentSurf, Brain Segmentation Volume Without Ventricles from Surf, 1157593.000000, mm^3
+# Measure Cortex, CortexVol, Total cortical gray matter volume, 454587.696158, mm^3
+# Measure SupraTentorial, SupraTentorialVol, Supratentorial volume, 1023873.000000, mm^3
+# Measure SupraTentorialNotVent, SupraTentorialVolNotVent, Supratentorial volume, 1012058.000000, mm^3
+# Measure EstimatedTotalIntraCranialVol, eTIV, Estimated Total Intracranial Volume, 1420434.160521, mm^3
+# NTableCols 10
+# TableCol  1 ColHeader StructName
+# TableCol  1 FieldName Structure Name
+# TableCol  1 Units     NA
+# TableCol  2 ColHeader NumVert
+# TableCol  2 FieldName Number of Vertices
+# TableCol  2 Units     unitless
+# TableCol  3 ColHeader SurfArea
+# TableCol  3 FieldName Surface Area
+# TableCol  3 Units     mm^2
+# TableCol  4 ColHeader GrayVol
+# TableCol  4 FieldName Gray Matter Volume
+# TableCol  4 Units     mm^3
+# TableCol  5 ColHeader ThickAvg 
+# TableCol  5 FieldName Average Thickness
+# TableCol  5 Units     mm
+# TableCol  6 ColHeader ThickStd
+# TableCol  6 FieldName Thickness StdDev
+# TableCol  6 Units     mm 
+# TableCol  7 ColHeader MeanCurv
+# TableCol  7 FieldName Integrated Rectified Mean Curvature
+# TableCol  7 Units     mm^-1
+# TableCol  8 ColHeader GausCurv 
+# TableCol  8 FieldName Integrated Rectified Gaussian Curvature
+# TableCol  8 Units     mm^-2
+# TableCol  9 ColHeader  FoldInd
+# TableCol  9 FieldName  Folding Index 
+# TableCol  9 Units      unitless 
+# TableCol 10 ColHeader CurvInd
+# TableCol 10 FieldName Intrinsic Curvature Index
+# TableCol 10 Units     unitless
+# ColHeaders StructName NumVert SurfArea GrayVol ThickAvg ThickStd MeanCurv GausCurv FoldInd CurvInd
+bankssts                                 1069    732   1536  2.144 0.501     0.109     0.021        7     1.0
+caudalanteriorcingulate                   861    559   1400  2.356 0.465     0.123     0.015        9     0.5
+caudalmiddlefrontal                      3635   2504   6949  2.492 0.571     0.114     0.022       29     3.4
+cuneus                                   2419   1740   3546  1.954 0.480     0.144     0.033       29     3.3
+entorhinal                                548    357   1673  3.053 0.883     0.082     0.018        3     0.3
+fusiform                                 3637   2723   7582  2.391 0.663     0.147     0.037       50     5.9
+inferiorparietal                         5697   4170  11237  2.366 0.575     0.134     0.030       60     7.1
+inferiortemporal                         3670   2730   7429  2.242 0.732     0.138     0.034       44     5.4
+isthmuscingulate                         1534   1043   2524  2.216 0.610     0.130     0.030       20     2.0
+lateraloccipital                         7117   5176  11787  2.107 0.541     0.144     0.035       85    10.6
+lateralorbitofrontal                     3716   2627   7928  2.754 0.771     0.132     0.034       45     5.7
+lingual                                  4256   3297   7791  2.167 0.591     0.159     0.043       59     7.9
+medialorbitofrontal                      2868   1979   6587  2.698 0.908     0.112     0.029       28     3.2
+middletemporal                           3466   2711   7508  2.136 0.678     0.142     0.039       47     5.8
+parahippocampal                           869    557   1942  2.905 0.822     0.094     0.022        5     0.7
+paracentral                              2463   1525   4322  2.661 0.585     0.102     0.019       15     2.0
+parsopercularis                          2485   1775   5018  2.506 0.609     0.114     0.024       21     2.4
+parsorbitalis                             890    704   2586  2.739 0.631     0.172     0.052       16     2.2
+parstriangularis                         1980   1438   4688  2.743 0.784     0.126     0.029       19     2.4
+pericalcarine                            2096   1524   2311  1.688 0.366     0.144     0.035       25     3.0
+postcentral                              6436   4475  10430  2.050 0.626     0.122     0.026       61     7.3
+posteriorcingulate                       1883   1261   3388  2.369 0.697     0.128     0.026       21     2.0
+precentral                               8010   5324  13626  2.403 0.626     0.116     0.025       66     8.7
+precuneus                                4973   3519   8876  2.349 0.519     0.124     0.026       46     5.3
+rostralanteriorcingulate                 1336    981   2452  2.138 0.702     0.147     0.041       21     2.7
+rostralmiddlefrontal                     7137   5404  16971  2.507 0.744     0.145     0.043       89    12.7
+superiorfrontal                         11318   7858  27120  2.894 0.733     0.119     0.027       94    12.6
+superiorparietal                         6602   4642  10653  2.128 0.536     0.128     0.027       67     7.2
+superiortemporal                         5500   3857  10626  2.377 0.641     0.116     0.027       50     6.8
+supramarginal                            5498   4140  10599  2.190 0.598     0.143     0.035       71     8.5
+frontalpole                               310    264   1203  3.167 1.032     0.223     0.072        8     1.1
+temporalpole                              717    540   2427  3.027 0.807     0.129     0.029        8     1.0
+transversetemporal                        757    535   1589  2.368 0.586     0.122     0.035        8     1.1
+insula                                   3215   2187   6352  2.897 0.721     0.116     0.028       25     3.6

--- a/tests/subjects/soichi/stats/lh.curv.stats
+++ b/tests/subjects/soichi/stats/lh.curv.stats
@@ -1,0 +1,220 @@
+
+Raw <mean> +- <std> (using 'lh.curv'):                -0.02314 +- 0.1621 
+       Raw Min:                                       -2.23337 at vertex 35075   
+       Raw Max:                                        1.19343 at vertex 68197   
+       Raw Curvature Calculation Type:                discrete
+       Raw Mean Vertex Separation (Whole Surface):     0.85839 +- 0.14471 mm
+       Raw Total Surface Area:                     80629.67188 mm^2
+       Raw Total Number of Vertices:                    127765
+       Raw Average Vertex Area (Whole Surface):        0.63108 mm^2
+       Raw Natural Surface Integral:               -1984.53455
+       Raw Rectified Surface Integral:             10314.14844
+       Raw Positive Surface Integral:               4164.80664
+       Raw Negative Surface Integral:               6149.34131
+       Raw Mean Natural Surface Integral:             -0.01553 across 127765 (100.00%) vertices
+       Raw Mean Rectified Surface Integral:            0.08073 across 127765 (100.00%) vertices
+       Raw Mean Positive Surface Integral:             0.06792 across 61323 (48.00%) vertices
+       Raw Mean Negative Surface Integral:             0.09255 across 66442 (52.00%) vertices
+       Raw AreaNorm Natural Surface Integral:         -0.02461 across 80629.421875 (100.00%) mm^2
+       Raw AreaNorm Rectified Surface Integral:        0.12792 across 80629.421875 (100.00%) mm^2
+       Raw AreaNorm Positive Surface Integral:         0.11034 across 37744.648438 (46.81%) mm^2
+       Raw AreaNorm Negative Surface Integral:         0.14339 across 42885.203125 (53.19%) mm^2
+
+Raw <mean> +- <std> (using 'lh.sulc'):                 0.00000 +- 5.6515 
+       Raw Min:                                      -13.69147 at vertex 73122   
+       Raw Max:                                       16.49734 at vertex 44539   
+       Raw Curvature Calculation Type:                discrete
+       Raw Mean Vertex Separation (Whole Surface):     0.85839 +- 0.14471 mm
+       Raw Total Surface Area:                     80629.67188 mm^2
+       Raw Total Number of Vertices:                    127765
+       Raw Average Vertex Area (Whole Surface):        0.63108 mm^2
+       Raw Natural Surface Integral:              -11830.13184
+       Raw Rectified Surface Integral:            372129.21875
+       Raw Positive Surface Integral:             180149.53125
+       Raw Negative Surface Integral:             191979.67188
+       Raw Mean Natural Surface Integral:             -0.09259 across 127765 (100.00%) vertices
+       Raw Mean Rectified Surface Integral:            2.91261 across 127765 (100.00%) vertices
+       Raw Mean Positive Surface Integral:             2.98706 across 60310 (47.20%) vertices
+       Raw Mean Negative Surface Integral:             2.84604 across 67455 (52.80%) vertices
+       Raw AreaNorm Natural Surface Integral:         -0.14672 across 80629.421875 (100.00%) mm^2
+       Raw AreaNorm Rectified Surface Integral:        4.61530 across 80629.421875 (100.00%) mm^2
+       Raw AreaNorm Positive Surface Integral:         4.86481 across 37031.179688 (45.93%) mm^2
+       Raw AreaNorm Negative Surface Integral:         4.40333 across 43598.703125 (54.07%) mm^2
+
+K <mean> +- <std> (using 'lh.smoothwm'):               0.40466 +- 128.7805 mm^-2
+         K Min:                                     -137.69644 at vertex 119955  
+         K Max:                                    45999.28516 at vertex 35075   
+         K Curvature Calculation Type:                discrete
+         K Mean Vertex Separation (Whole Surface):     0.85839 +- 0.14471 mm
+         K Total Surface Area:                     80629.67188 mm^2
+         K Total Number of Vertices:                    127765
+         K Average Vertex Area (Whole Surface):        0.63108 mm^2
+         K Natural Surface Integral:                  10.03039
+         K Rectified Surface Integral:              3722.81152
+         K Positive Surface Integral:               1866.42090
+         K Negative Surface Integral:               1856.39050
+         K Mean Natural Surface Integral:              0.00008 across 127765 (100.00%) vertices
+         K Mean Rectified Surface Integral:            0.02914 across 127765 (100.00%) vertices
+         K Mean Positive Surface Integral:             0.03180 across 58690 (45.94%) vertices
+         K Mean Negative Surface Integral:             0.02687 across 69075 (54.06%) vertices
+         K AreaNorm Natural Surface Integral:          0.00012 across 80629.421875 (100.00%) mm^2
+         K AreaNorm Rectified Surface Integral:        0.04617 across 80629.421875 (100.00%) mm^2
+         K AreaNorm Positive Surface Integral:         0.05603 across 33309.593750 (41.31%) mm^2
+         K AreaNorm Negative Surface Integral:         0.03923 across 47319.820312 (58.69%) mm^2
+
+H <mean> +- <std> (using 'lh.smoothwm'):              -0.02908 +- 3.3661 mm^-1
+         H Min:                                     -522.82898 at vertex 119812  
+         H Max:                                     1013.19629 at vertex 35075   
+         H Curvature Calculation Type:                discrete
+         H Mean Vertex Separation (Whole Surface):     0.85839 +- 0.14471 mm
+         H Total Surface Area:                     80629.67188 mm^2
+         H Total Number of Vertices:                    127765
+         H Average Vertex Area (Whole Surface):        0.63108 mm^2
+         H Natural Surface Integral:               -1761.99780
+         H Rectified Surface Integral:             13818.12891
+         H Positive Surface Integral:               6028.06592
+         H Negative Surface Integral:               7790.06348
+         H Mean Natural Surface Integral:             -0.01379 across 127765 (100.00%) vertices
+         H Mean Rectified Surface Integral:            0.10815 across 127765 (100.00%) vertices
+         H Mean Positive Surface Integral:             0.09073 across 66436 (52.00%) vertices
+         H Mean Negative Surface Integral:             0.12702 across 61329 (48.00%) vertices
+         H AreaNorm Natural Surface Integral:         -0.02185 across 80629.421875 (100.00%) mm^2
+         H AreaNorm Rectified Surface Integral:        0.17138 across 80629.421875 (100.00%) mm^2
+         H AreaNorm Positive Surface Integral:         0.14318 across 42101.167969 (52.22%) mm^2
+         H AreaNorm Negative Surface Integral:         0.20219 across 38528.816406 (47.78%) mm^2
+
+k1 <mean> +- <std> (using 'lh.smoothwm'):             -0.06000 +- 6.6697 mm^-1
+        k1 Min:                                    -1045.17017 at vertex 119812  
+        k1 Max:                                     2003.43237 at vertex 35075   
+        k1 Curvature Calculation Type:                discrete
+        k1 Mean Vertex Separation (Whole Surface):     0.85839 +- 0.14471 mm
+        k1 Total Surface Area:                     80629.67188 mm^2
+        k1 Total Number of Vertices:                    127765
+        k1 Average Vertex Area (Whole Surface):        0.63108 mm^2
+        k1 Natural Surface Integral:               -3943.13159
+        k1 Rectified Surface Integral:             29239.86328
+        k1 Positive Surface Integral:              12648.36621
+        k1 Negative Surface Integral:              16591.49805
+        k1 Mean Natural Surface Integral:             -0.03086 across 127765 (100.00%) vertices
+        k1 Mean Rectified Surface Integral:            0.22886 across 127765 (100.00%) vertices
+        k1 Mean Positive Surface Integral:             0.19038 across 66436 (52.00%) vertices
+        k1 Mean Negative Surface Integral:             0.27053 across 61329 (48.00%) vertices
+        k1 AreaNorm Natural Surface Integral:         -0.04890 across 80629.421875 (100.00%) mm^2
+        k1 AreaNorm Rectified Surface Integral:        0.36265 across 80629.421875 (100.00%) mm^2
+        k1 AreaNorm Positive Surface Integral:         0.30043 across 42101.167969 (52.22%) mm^2
+        k1 AreaNorm Negative Surface Integral:         0.43063 across 38528.816406 (47.78%) mm^2
+
+k2 <mean> +- <std> (using 'lh.smoothwm'):              0.00183 +- 0.1699 mm^-1
+        k2 Min:                                      -14.41974 at vertex 67492   
+        k2 Max:                                       22.96024 at vertex 35075   
+        k2 Curvature Calculation Type:                discrete
+        k2 Mean Vertex Separation (Whole Surface):     0.85839 +- 0.14471 mm
+        k2 Total Surface Area:                     80629.67188 mm^2
+        k2 Total Number of Vertices:                    127765
+        k2 Average Vertex Area (Whole Surface):        0.63108 mm^2
+        k2 Natural Surface Integral:                 419.13602
+        k2 Rectified Surface Integral:              7187.33398
+        k2 Positive Surface Integral:               3803.23486
+        k2 Negative Surface Integral:               3384.09888
+        k2 Mean Natural Surface Integral:              0.00328 across 127765 (100.00%) vertices
+        k2 Mean Rectified Surface Integral:            0.05625 across 127765 (100.00%) vertices
+        k2 Mean Positive Surface Integral:             0.05627 across 67591 (52.90%) vertices
+        k2 Mean Negative Surface Integral:             0.05624 across 60174 (47.10%) vertices
+        k2 AreaNorm Natural Surface Integral:          0.00520 across 80629.421875 (100.00%) mm^2
+        k2 AreaNorm Rectified Surface Integral:        0.08914 across 80629.421875 (100.00%) mm^2
+        k2 AreaNorm Positive Surface Integral:         0.08932 across 42580.980469 (52.81%) mm^2
+        k2 AreaNorm Negative Surface Integral:         0.08894 across 38048.824219 (47.19%) mm^2
+
+S <mean> +- <std> (using 'lh.smoothwm'):              43.70791 +- 11439.3973 mm^-2
+         S Min:                                        0.00000 at vertex 45      
+         S Max:                                   3922270.00000 at vertex 35075   
+         S Curvature Calculation Type:                discrete
+         S Mean Vertex Separation (Whole Surface):     0.85839 +- 0.14471 mm
+         S Total Surface Area:                     80629.67188 mm^2
+         S Total Number of Vertices:                    127765
+         S Average Vertex Area (Whole Surface):        0.63108 mm^2
+         S Natural Surface Integral:               22523.45703
+         S Rectified Surface Integral:             22523.45703
+         S Positive Surface Integral:              22523.45703
+         S Negative Surface Integral:                  0.00000
+         S Mean Natural Surface Integral:              0.17629 across 127765 (100.00%) vertices
+         S Mean Rectified Surface Integral:            0.17629 across 127765 (100.00%) vertices
+         S Mean Positive Surface Integral:             0.17629 across 127765 (100.00%) vertices
+         S Mean Negative Surface Integral:             0.00000 across 0 (00.00%) vertices
+         S AreaNorm Natural Surface Integral:          0.27935 across 80629.421875 (100.00%) mm^2
+         S AreaNorm Rectified Surface Integral:        0.27935 across 80629.421875 (100.00%) mm^2
+         S AreaNorm Positive Surface Integral:         0.27935 across 80629.421875 (100.00%) mm^2
+         S AreaNorm Negative Surface Integral:         0.00000 across 0.000000 (00.00%) mm^2
+
+C <mean> +- <std> (using 'lh.smoothwm'):               0.33225 +- 4.7062 mm^-2
+         C Min:                                        0.00550 at vertex 75114   
+         C Max:                                     1416.73364 at vertex 35075   
+         C Curvature Calculation Type:                discrete
+         C Mean Vertex Separation (Whole Surface):     0.85839 +- 0.14471 mm
+         C Total Surface Area:                     80629.67188 mm^2
+         C Total Number of Vertices:                    127765
+         C Average Vertex Area (Whole Surface):        0.63108 mm^2
+         C Natural Surface Integral:               21689.17969
+         C Rectified Surface Integral:             21689.17969
+         C Positive Surface Integral:              21689.17969
+         C Negative Surface Integral:                  0.00000
+         C Mean Natural Surface Integral:              0.16976 across 127765 (100.00%) vertices
+         C Mean Rectified Surface Integral:            0.16976 across 127765 (100.00%) vertices
+         C Mean Positive Surface Integral:             0.16976 across 127765 (100.00%) vertices
+         C Mean Negative Surface Integral:             0.00000 across 0 (00.00%) vertices
+         C AreaNorm Natural Surface Integral:          0.26900 across 80629.421875 (100.00%) mm^2
+         C AreaNorm Rectified Surface Integral:        0.26900 across 80629.421875 (100.00%) mm^2
+         C AreaNorm Positive Surface Integral:         0.26900 across 80629.421875 (100.00%) mm^2
+         C AreaNorm Negative Surface Integral:         0.00000 across 0.000000 (00.00%) mm^2
+
+BE <mean> +- <std> (using 'lh.smoothwm'):             44.51705 +- 11687.2143 mm^-2
+        BE Min:                                        0.00006 at vertex 75114   
+        BE Max:                                   4014268.50000 at vertex 35075   
+        BE Curvature Calculation Type:                discrete
+        BE Mean Vertex Separation (Whole Surface):     0.85839 +- 0.14471 mm
+        BE Total Surface Area:                     80629.67188 mm^2
+        BE Total Number of Vertices:                    127765
+        BE Average Vertex Area (Whole Surface):        0.63108 mm^2
+        BE Natural Surface Integral:               22542.37305
+        BE Rectified Surface Integral:             22542.37305
+        BE Positive Surface Integral:              22542.37305
+        BE Negative Surface Integral:                  0.00000
+        BE Mean Natural Surface Integral:              0.17644 across 127765 (100.00%) vertices
+        BE Mean Rectified Surface Integral:            0.17644 across 127765 (100.00%) vertices
+        BE Mean Positive Surface Integral:             0.17644 across 127765 (100.00%) vertices
+        BE Mean Negative Surface Integral:             0.00000 across 0 (00.00%) vertices
+        BE AreaNorm Natural Surface Integral:          0.27958 across 80629.421875 (100.00%) mm^2
+        BE AreaNorm Rectified Surface Integral:        0.27958 across 80629.421875 (100.00%) mm^2
+        BE AreaNorm Positive Surface Integral:         0.27958 across 80629.421875 (100.00%) mm^2
+        BE AreaNorm Negative Surface Integral:         0.00000 across 0.000000 (00.00%) mm^2
+
+FI <mean> +- <std> (using 'lh.smoothwm'):             44.03400 +- 11561.7650 mm^-2
+        FI Min:                                        0.00000 at vertex 45      
+        FI Max:                                   3967742.00000 at vertex 35075   
+        FI Curvature Calculation Type:                discrete
+        FI Mean Vertex Separation (Whole Surface):     0.85839 +- 0.14471 mm
+        FI Total Surface Area:                     80629.67188 mm^2
+        FI Total Number of Vertices:                    127765
+        FI Average Vertex Area (Whole Surface):        0.63108 mm^2
+        FI Natural Surface Integral:               17500.04883
+        FI Rectified Surface Integral:             17500.04883
+        FI Positive Surface Integral:              17500.04883
+        FI Negative Surface Integral:                  0.00000
+        FI Mean Natural Surface Integral:              0.13697 across 127765 (100.00%) vertices
+        FI Mean Rectified Surface Integral:            0.13697 across 127765 (100.00%) vertices
+        FI Mean Positive Surface Integral:             0.13697 across 127765 (100.00%) vertices
+        FI Mean Negative Surface Integral:             0.00000 across 0 (00.00%) vertices
+        FI AreaNorm Natural Surface Integral:          0.21704 across 80629.421875 (100.00%) mm^2
+        FI AreaNorm Rectified Surface Integral:        0.21704 across 80629.421875 (100.00%) mm^2
+        FI AreaNorm Positive Surface Integral:         0.21704 across 80629.421875 (100.00%) mm^2
+        FI AreaNorm Negative Surface Integral:         0.00000 across 0.000000 (00.00%) mm^2
+
+curv -- calculation type:                                discrete
+curv -- Folding Index (FI):                            1392.60962
+curv -- Intrinsic Curvature Index - positive (ICIp):    148.52505
+curv -- Intrinsic Curvature Index - negative (ICIn):    147.72687
+curv -- Intrinsic Curvature Index - natural  (ICIt):      0.79819
+
+Mean across 10 curvatures: 1.3289e+01 +- 2.0163e+01
+
+

--- a/tests/subjects/soichi/stats/lh.w-g.pct.stats
+++ b/tests/subjects/soichi/stats/lh.w-g.pct.stats
@@ -1,0 +1,92 @@
+# Title Segmentation Statistics 
+# 
+# generating_program mri_segstats
+# cvs_version 7.0.0
+# cmdline mri_segstats --in /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f/output/surf/lh.w-g.pct.mgh --annot output lh aparc --sum /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f/output/stats/lh.w-g.pct.stats --snr 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# anatomy_type surface
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# subjectname output
+# Annot output lh aparc
+# ColorTable /tmp/mri_segstats.tmp.output.lh.176.ctab 
+# ColorTableTimeStamp 2020/05/04 22:13:42 
+# InVolFile  /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f/output/surf/lh.w-g.pct.mgh 
+# InVolFileTimeStamp  2020/05/04 22:13:41 
+# InVolFrame 0 
+# Only reporting non-empty segmentations
+# VertexArea_mm2 0.706017 
+# TableCol  1 ColHeader Index 
+# TableCol  1 FieldName Index 
+# TableCol  1 Units     NA 
+# TableCol  2 ColHeader SegId 
+# TableCol  2 FieldName Segmentation Id
+# TableCol  2 Units     NA
+# TableCol  3 ColHeader NVertices 
+# TableCol  3 FieldName Number of Vertices
+# TableCol  3 Units     unitless
+# TableCol  4 ColHeader Area_mm2
+# TableCol  4 FieldName Area
+# TableCol  4 Units     mm^2
+# TableCol  5 ColHeader StructName
+# TableCol  5 FieldName Structure Name
+# TableCol  5 Units     NA
+# TableCol  6 ColHeader Mean 
+# TableCol  6 FieldName Intensity Mean
+# TableCol  6 Units     unknown
+# TableCol  7 ColHeader StdDev
+# TableCol  7 FieldName Itensity StdDev
+# TableCol  7 Units     unknown
+# TableCol  8 ColHeader Min
+# TableCol  8 FieldName Intensity Min
+# TableCol  8 Units     unknown
+# TableCol  9 ColHeader Max
+# TableCol  9 FieldName Intensity Max
+# TableCol  9 Units     unknown
+# TableCol 10 ColHeader Range
+# TableCol 10 FieldName Intensity Range
+# TableCol 10 Units     unknown
+# TableCol 11 ColHeader SNR
+# TableCol 11 FieldName Intensity SNR
+# TableCol 11 Units     none
+# NRows 35 
+# NTableCols 11 
+# ColHeaders  Index SegId NVertices Area_mm2 StructName Mean StdDev Min Max Range SNR  
+  1 1000      8797     5346.4  unknown                            0.0000     0.0000     0.0000     0.0000     0.0000       -nan 
+  2 1001      1069      732.4  bankssts                          32.2310     5.3339    13.6829    48.0815    34.3986     6.0427 
+  3 1002       861      559.2  caudalanteriorcingulate           31.3112     4.6469    17.7241    46.0977    28.3735     6.7381 
+  4 1003      3635     2504.1  caudalmiddlefrontal               29.5928     5.5888    10.0731    48.7656    38.6926     5.2950 
+  5 1005      2419     1739.6  cuneus                            25.2280     6.2290     3.6358    41.8373    38.2015     4.0501 
+  6 1006       548      356.7  entorhinal                        28.2899     7.3982    -7.7086    46.4734    54.1820     3.8239 
+  7 1007      3637     2722.8  fusiform                          28.7506     8.0572    -5.0947    52.6563    57.7510     3.5683 
+  8 1008      5697     4169.8  inferiorparietal                  30.2667     6.5324     2.9106    55.0659    52.1553     4.6333 
+  9 1009      3670     2730.3  inferiortemporal                  29.4551     7.6850    -1.7111    56.8518    58.5629     3.8328 
+ 10 1010      1534     1043.5  isthmuscingulate                  26.1780     7.1462    -0.3036    44.9696    45.2732     3.6632 
+ 11 1011      7117     5175.7  lateraloccipital                  26.3339     7.2197    -7.5046    59.8515    67.3560     3.6475 
+ 12 1012      3716     2627.1  lateralorbitofrontal              30.7968     8.8976    -2.6993    59.8120    62.5113     3.4612 
+ 13 1013      4256     3297.0  lingual                           24.2993     8.0033   -25.3325    45.9461    71.2786     3.0361 
+ 14 1014      2868     1978.5  medialorbitofrontal               27.3374    12.8968   -58.0681    61.0749   119.1430     2.1197 
+ 15 1015      3466     2711.5  middletemporal                    27.2499     7.7445   -27.7069    55.6032    83.3101     3.5186 
+ 16 1016       869      556.6  parahippocampal                   30.6419     6.8118     9.0265    49.0164    39.9899     4.4983 
+ 17 1017      2463     1524.7  paracentral                       26.1351     7.9326     3.9247    51.3411    47.4164     3.2946 
+ 18 1018      2485     1775.3  parsopercularis                   31.0387     6.1284     8.3338    51.9747    43.6409     5.0647 
+ 19 1019       890      703.9  parsorbitalis                     29.9108     7.2716     1.1074    53.7103    52.6029     4.1134 
+ 20 1020      1980     1437.7  parstriangularis                  30.2547     7.0696     5.0913    57.3916    52.3003     4.2795 
+ 21 1021      2096     1523.6  pericalcarine                     23.4158     5.6427     2.5075    46.6393    44.1318     4.1497 
+ 22 1022      6436     4474.9  postcentral                       26.7588     6.7065    -7.2445    52.7955    60.0399     3.9900 
+ 23 1023      1883     1261.1  posteriorcingulate                29.2603     7.3855    -1.1920    50.3276    51.5196     3.9618 
+ 24 1024      8010     5323.7  precentral                        24.3475     7.2082     1.0214    47.3662    46.3448     3.3777 
+ 25 1025      4973     3519.0  precuneus                         29.6542     6.4972   -12.0707    49.6958    61.7665     4.5641 
+ 26 1026      1336      981.4  rostralanteriorcingulate          31.3890    11.7888   -33.9684    70.7572   104.7256     2.6626 
+ 27 1027      7137     5404.1  rostralmiddlefrontal              29.2840     7.3864    -6.2795    64.3289    70.6084     3.9646 
+ 28 1028     11318     7858.0  superiorfrontal                   30.6001     6.6785     6.2469    55.9067    49.6598     4.5819 
+ 29 1029      6602     4641.6  superiorparietal                  28.5048     6.1060   -17.2151    49.2834    66.4985     4.6684 
+ 30 1030      5500     3856.9  superiortemporal                  30.7228     7.6514   -42.4546    68.2752   110.7298     4.0153 
+ 31 1031      5498     4140.2  supramarginal                     29.1747     7.1918   -10.4217    53.5430    63.9648     4.0567 
+ 32 1032       310      264.3  frontalpole                       29.4264    11.7401    -3.3167    54.0117    57.3284     2.5065 
+ 33 1033       717      540.0  temporalpole                      29.7048     9.6077    -1.6414    55.7050    57.3464     3.0918 
+ 34 1034       757      535.3  transversetemporal                24.5779     6.8058    -4.0446    44.1972    48.2418     3.6113 
+ 35 1035      3215     2187.4  insula                            27.3214     8.4217     0.9642    57.2715    56.3072     3.2442 

--- a/tests/subjects/soichi/stats/rh.BA_exvivo.stats
+++ b/tests/subjects/soichi/stats/rh.BA_exvivo.stats
@@ -1,0 +1,74 @@
+# Table of FreeSurfer cortical parcellation anatomical statistics 
+# 
+# CreationTime 2020/05/04-22:23:59-GMT
+# generating_program mris_anatomical_stats
+# cvs_version 7.0.0
+# mrisurf.c-cvs_version 7.0.0
+# cmdline mris_anatomical_stats -th3 -mgz -f ../stats/rh.BA_exvivo.stats -b -a ./rh.BA_exvivo.annot -c ./BA_exvivo.ctab output rh white 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# anatomy_type surface
+# subjectname output
+# hemi rh
+# AnnotationFile ./rh.BA_exvivo.annot
+# AnnotationFileTimeStamp 2020/05/04 22:23:55
+# Measure Cortex, NumVert, Number of Vertices, 124680, unitless
+# Measure Cortex, WhiteSurfArea, White Surface Total Area, 88998.7, mm^2
+# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3
+# Measure BrainSeg, BrainSegVol, Brain Segmentation Volume, 1169408.000000, mm^3
+# Measure BrainSegNotVent, BrainSegVolNotVent, Brain Segmentation Volume Without Ventricles, 1157593.000000, mm^3
+# Measure BrainSegNotVentSurf, BrainSegVolNotVentSurf, Brain Segmentation Volume Without Ventricles from Surf, 1157593.000000, mm^3
+# Measure Cortex, CortexVol, Total cortical gray matter volume, 454587.696158, mm^3
+# Measure SupraTentorial, SupraTentorialVol, Supratentorial volume, 1023873.000000, mm^3
+# Measure SupraTentorialNotVent, SupraTentorialVolNotVent, Supratentorial volume, 1012058.000000, mm^3
+# Measure EstimatedTotalIntraCranialVol, eTIV, Estimated Total Intracranial Volume, 1420434.160521, mm^3
+# NTableCols 10
+# TableCol  1 ColHeader StructName
+# TableCol  1 FieldName Structure Name
+# TableCol  1 Units     NA
+# TableCol  2 ColHeader NumVert
+# TableCol  2 FieldName Number of Vertices
+# TableCol  2 Units     unitless
+# TableCol  3 ColHeader SurfArea
+# TableCol  3 FieldName Surface Area
+# TableCol  3 Units     mm^2
+# TableCol  4 ColHeader GrayVol
+# TableCol  4 FieldName Gray Matter Volume
+# TableCol  4 Units     mm^3
+# TableCol  5 ColHeader ThickAvg 
+# TableCol  5 FieldName Average Thickness
+# TableCol  5 Units     mm
+# TableCol  6 ColHeader ThickStd
+# TableCol  6 FieldName Thickness StdDev
+# TableCol  6 Units     mm 
+# TableCol  7 ColHeader MeanCurv
+# TableCol  7 FieldName Integrated Rectified Mean Curvature
+# TableCol  7 Units     mm^-1
+# TableCol  8 ColHeader GausCurv 
+# TableCol  8 FieldName Integrated Rectified Gaussian Curvature
+# TableCol  8 Units     mm^-2
+# TableCol  9 ColHeader  FoldInd
+# TableCol  9 FieldName  Folding Index 
+# TableCol  9 Units      unitless 
+# TableCol 10 ColHeader CurvInd
+# TableCol 10 FieldName Intrinsic Curvature Index
+# TableCol 10 Units     unitless
+# ColHeaders StructName NumVert SurfArea GrayVol ThickAvg ThickStd MeanCurv GausCurv FoldInd CurvInd
+BA1_exvivo                                930    649   1737  2.100 0.480     0.155     0.039       13     1.7
+BA2_exvivo                               3134   2104   4086  1.917 0.451     0.103     0.021       20     2.5
+BA3a_exvivo                              1089    718   1008  1.853 0.435     0.128     0.028       10     1.2
+BA3b_exvivo                              1794   1267   2578  1.751 0.531     0.104     0.021       12     1.7
+BA4a_exvivo                              1520    881   2971  2.877 0.672     0.100     0.028        9     1.9
+BA4p_exvivo                              1249    801   1810  2.269 0.570     0.091     0.019        6     0.9
+BA6_exvivo                               8152   5352  17057  2.813 0.621     0.114     0.024       64     8.3
+BA44_exvivo                              3838   2774   7530  2.500 0.565     0.124     0.027       36     4.4
+BA45_exvivo                              3951   3075   9056  2.442 0.662     0.141     0.037       48     6.2
+V1_exvivo                                3891   2885   5389  1.792 0.531     0.150     0.040       47     6.7
+V2_exvivo                                7820   5770  12321  2.037 0.535     0.156     0.042      106    14.0
+MT_exvivo                                1835   1377   3357  2.205 0.505     0.149     0.037       21     2.9
+perirhinal_exvivo                         287    210    709  2.758 0.562     0.100     0.023        1     0.4
+entorhinal_exvivo                         462    320   1567  2.977 1.227     0.123     0.033        5     0.5

--- a/tests/subjects/soichi/stats/rh.BA_exvivo.thresh.stats
+++ b/tests/subjects/soichi/stats/rh.BA_exvivo.thresh.stats
@@ -1,0 +1,74 @@
+# Table of FreeSurfer cortical parcellation anatomical statistics 
+# 
+# CreationTime 2020/05/04-22:24:03-GMT
+# generating_program mris_anatomical_stats
+# cvs_version 7.0.0
+# mrisurf.c-cvs_version 7.0.0
+# cmdline mris_anatomical_stats -th3 -mgz -f ../stats/rh.BA_exvivo.thresh.stats -b -a ./rh.BA_exvivo.thresh.annot -c ./BA_exvivo.thresh.ctab output rh white 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# anatomy_type surface
+# subjectname output
+# hemi rh
+# AnnotationFile ./rh.BA_exvivo.thresh.annot
+# AnnotationFileTimeStamp 2020/05/04 22:23:56
+# Measure Cortex, NumVert, Number of Vertices, 124680, unitless
+# Measure Cortex, WhiteSurfArea, White Surface Total Area, 88998.7, mm^2
+# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3
+# Measure BrainSeg, BrainSegVol, Brain Segmentation Volume, 1169408.000000, mm^3
+# Measure BrainSegNotVent, BrainSegVolNotVent, Brain Segmentation Volume Without Ventricles, 1157593.000000, mm^3
+# Measure BrainSegNotVentSurf, BrainSegVolNotVentSurf, Brain Segmentation Volume Without Ventricles from Surf, 1157593.000000, mm^3
+# Measure Cortex, CortexVol, Total cortical gray matter volume, 454587.696158, mm^3
+# Measure SupraTentorial, SupraTentorialVol, Supratentorial volume, 1023873.000000, mm^3
+# Measure SupraTentorialNotVent, SupraTentorialVolNotVent, Supratentorial volume, 1012058.000000, mm^3
+# Measure EstimatedTotalIntraCranialVol, eTIV, Estimated Total Intracranial Volume, 1420434.160521, mm^3
+# NTableCols 10
+# TableCol  1 ColHeader StructName
+# TableCol  1 FieldName Structure Name
+# TableCol  1 Units     NA
+# TableCol  2 ColHeader NumVert
+# TableCol  2 FieldName Number of Vertices
+# TableCol  2 Units     unitless
+# TableCol  3 ColHeader SurfArea
+# TableCol  3 FieldName Surface Area
+# TableCol  3 Units     mm^2
+# TableCol  4 ColHeader GrayVol
+# TableCol  4 FieldName Gray Matter Volume
+# TableCol  4 Units     mm^3
+# TableCol  5 ColHeader ThickAvg 
+# TableCol  5 FieldName Average Thickness
+# TableCol  5 Units     mm
+# TableCol  6 ColHeader ThickStd
+# TableCol  6 FieldName Thickness StdDev
+# TableCol  6 Units     mm 
+# TableCol  7 ColHeader MeanCurv
+# TableCol  7 FieldName Integrated Rectified Mean Curvature
+# TableCol  7 Units     mm^-1
+# TableCol  8 ColHeader GausCurv 
+# TableCol  8 FieldName Integrated Rectified Gaussian Curvature
+# TableCol  8 Units     mm^-2
+# TableCol  9 ColHeader  FoldInd
+# TableCol  9 FieldName  Folding Index 
+# TableCol  9 Units      unitless 
+# TableCol 10 ColHeader CurvInd
+# TableCol 10 FieldName Intrinsic Curvature Index
+# TableCol 10 Units     unitless
+# ColHeaders StructName NumVert SurfArea GrayVol ThickAvg ThickStd MeanCurv GausCurv FoldInd CurvInd
+BA1_exvivo                                634    455   1215  2.084 0.461     0.162     0.042        8     1.3
+BA2_exvivo                               1783   1203   2516  1.911 0.460     0.093     0.016        9     1.2
+BA3a_exvivo                               982    642    826  1.852 0.411     0.135     0.027        9     1.2
+BA3b_exvivo                              1404    962   1561  1.574 0.361     0.086     0.015        6     0.9
+BA4a_exvivo                               967    527   1977  3.050 0.631     0.108     0.036        7     1.5
+BA4p_exvivo                              1049    672   1437  2.180 0.562     0.092     0.021        4     0.9
+BA6_exvivo                               5250   3410  10858  2.791 0.604     0.114     0.025       42     5.4
+BA44_exvivo                               969    718   2031  2.316 0.535     0.135     0.024       12     0.9
+BA45_exvivo                               893    755   2738  2.690 0.781     0.156     0.050       14     1.9
+V1_exvivo                                3749   2739   4991  1.778 0.520     0.147     0.040       44     6.2
+V2_exvivo                                4117   3119   6544  1.982 0.556     0.161     0.046       58     8.0
+MT_exvivo                                 245    182    395  2.050 0.414     0.148     0.049        3     0.4
+perirhinal_exvivo                          24     17     54  2.892 0.427     0.055     0.014        0     0.0
+entorhinal_exvivo                         451    296   1500  3.200 0.820     0.095     0.024        3     0.3

--- a/tests/subjects/soichi/stats/rh.aparc.DKTatlas.stats
+++ b/tests/subjects/soichi/stats/rh.aparc.DKTatlas.stats
@@ -1,0 +1,92 @@
+# Table of FreeSurfer cortical parcellation anatomical statistics 
+# 
+# CreationTime 2020/05/04-22:20:53-GMT
+# generating_program mris_anatomical_stats
+# cvs_version 7.0.0
+# mrisurf.c-cvs_version 7.0.0
+# cmdline mris_anatomical_stats -th3 -mgz -cortex ../label/rh.cortex.label -f ../stats/rh.aparc.DKTatlas.stats -b -a ../label/rh.aparc.DKTatlas.annot -c ../label/aparc.annot.DKTatlas.ctab output rh white 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# anatomy_type surface
+# subjectname output
+# hemi rh
+# AnnotationFile ../label/rh.aparc.DKTatlas.annot
+# AnnotationFileTimeStamp 2020/05/04 22:13:39
+# Measure Cortex, NumVert, Number of Vertices, 115827, unitless
+# Measure Cortex, WhiteSurfArea, White Surface Total Area, 83579.2, mm^2
+# Measure Cortex, MeanThickness, Mean Thickness, 2.35815, mm
+# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3
+# Measure BrainSeg, BrainSegVol, Brain Segmentation Volume, 1169408.000000, mm^3
+# Measure BrainSegNotVent, BrainSegVolNotVent, Brain Segmentation Volume Without Ventricles, 1157593.000000, mm^3
+# Measure BrainSegNotVentSurf, BrainSegVolNotVentSurf, Brain Segmentation Volume Without Ventricles from Surf, 1157593.000000, mm^3
+# Measure Cortex, CortexVol, Total cortical gray matter volume, 454587.696158, mm^3
+# Measure SupraTentorial, SupraTentorialVol, Supratentorial volume, 1023873.000000, mm^3
+# Measure SupraTentorialNotVent, SupraTentorialVolNotVent, Supratentorial volume, 1012058.000000, mm^3
+# Measure EstimatedTotalIntraCranialVol, eTIV, Estimated Total Intracranial Volume, 1420434.160521, mm^3
+# NTableCols 10
+# TableCol  1 ColHeader StructName
+# TableCol  1 FieldName Structure Name
+# TableCol  1 Units     NA
+# TableCol  2 ColHeader NumVert
+# TableCol  2 FieldName Number of Vertices
+# TableCol  2 Units     unitless
+# TableCol  3 ColHeader SurfArea
+# TableCol  3 FieldName Surface Area
+# TableCol  3 Units     mm^2
+# TableCol  4 ColHeader GrayVol
+# TableCol  4 FieldName Gray Matter Volume
+# TableCol  4 Units     mm^3
+# TableCol  5 ColHeader ThickAvg 
+# TableCol  5 FieldName Average Thickness
+# TableCol  5 Units     mm
+# TableCol  6 ColHeader ThickStd
+# TableCol  6 FieldName Thickness StdDev
+# TableCol  6 Units     mm 
+# TableCol  7 ColHeader MeanCurv
+# TableCol  7 FieldName Integrated Rectified Mean Curvature
+# TableCol  7 Units     mm^-1
+# TableCol  8 ColHeader GausCurv 
+# TableCol  8 FieldName Integrated Rectified Gaussian Curvature
+# TableCol  8 Units     mm^-2
+# TableCol  9 ColHeader  FoldInd
+# TableCol  9 FieldName  Folding Index 
+# TableCol  9 Units      unitless 
+# TableCol 10 ColHeader CurvInd
+# TableCol 10 FieldName Intrinsic Curvature Index
+# TableCol 10 Units     unitless
+# ColHeaders StructName NumVert SurfArea GrayVol ThickAvg ThickStd MeanCurv GausCurv FoldInd CurvInd
+caudalanteriorcingulate                  1234    843   2483  2.826 0.653     0.116     0.021       12     1.1
+caudalmiddlefrontal                      3263   2302   6175  2.437 0.598     0.121     0.024       28     3.3
+cuneus                                   3039   2191   4262  1.875 0.433     0.143     0.034       34     4.3
+entorhinal                                339    221   1184  3.262 0.690     0.082     0.020        2     0.2
+fusiform                                 3025   2175   5785  2.301 0.632     0.134     0.032       33     4.3
+inferiorparietal                         7091   5312  13161  2.156 0.571     0.134     0.030       83     9.3
+inferiortemporal                         3125   2424   7370  2.404 0.740     0.150     0.040       43     5.6
+isthmuscingulate                         1429   1072   2726  2.337 0.645     0.157     0.047       24     2.8
+lateraloccipital                         6301   4719  10910  2.156 0.570     0.159     0.041       85    10.7
+lateralorbitofrontal                     4093   3005   8648  2.499 0.811     0.157     0.049       75     8.5
+lingual                                  4818   3551   8027  2.104 0.597     0.146     0.040       62     8.4
+medialorbitofrontal                      2435   1814   5921  2.650 0.902     0.138     0.043       37     4.7
+middletemporal                           4283   3366   9002  2.240 0.636     0.133     0.034       54     6.3
+parahippocampal                           940    605   1737  2.401 0.753     0.094     0.020        6     0.7
+paracentral                              2462   1485   4530  2.772 0.712     0.097     0.023       15     2.3
+parsopercularis                          2317   1693   4539  2.421 0.664     0.127     0.028       24     2.9
+parsorbitalis                            1029    772   2232  2.399 0.653     0.128     0.028       11     1.1
+parstriangularis                         2131   1625   4888  2.521 0.651     0.138     0.039       24     3.5
+pericalcarine                            2216   1566   2263  1.639 0.413     0.143     0.037       24     3.3
+postcentral                              6477   4492   9747  1.963 0.553     0.115     0.025       53     6.8
+posteriorcingulate                       1839   1312   3870  2.648 0.790     0.137     0.030       23     2.3
+precentral                               7455   4896  12964  2.454 0.576     0.117     0.026       58     8.7
+precuneus                                5795   4018  10401  2.417 0.594     0.123     0.026       53     6.1
+rostralanteriorcingulate                 1162    887   2740  2.556 0.842     0.146     0.038       15     2.1
+rostralmiddlefrontal                     5319   4203  11722  2.318 0.704     0.146     0.038       68     9.0
+superiorfrontal                         11609   8131  27456  2.845 0.717     0.125     0.031      105    14.5
+superiorparietal                         6308   4392   9679  2.032 0.542     0.122     0.024       57     6.1
+superiortemporal                         6551   4880  13659  2.356 0.710     0.131     0.037       86    10.9
+supramarginal                            4425   3332   8213  2.237 0.625     0.139     0.036       54     7.0
+transversetemporal                        522    410    954  2.026 0.540     0.192     0.069       14     1.4
+insula                                   2795   1885   5518  2.942 0.772     0.110     0.024       21     2.7

--- a/tests/subjects/soichi/stats/rh.aparc.a2009s.stats
+++ b/tests/subjects/soichi/stats/rh.aparc.a2009s.stats
@@ -1,0 +1,135 @@
+# Table of FreeSurfer cortical parcellation anatomical statistics 
+# 
+# CreationTime 2020/05/04-22:20:40-GMT
+# generating_program mris_anatomical_stats
+# cvs_version 7.0.0
+# mrisurf.c-cvs_version 7.0.0
+# cmdline mris_anatomical_stats -th3 -mgz -cortex ../label/rh.cortex.label -f ../stats/rh.aparc.a2009s.stats -b -a ../label/rh.aparc.a2009s.annot -c ../label/aparc.annot.a2009s.ctab output rh white 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# anatomy_type surface
+# subjectname output
+# hemi rh
+# AnnotationFile ../label/rh.aparc.a2009s.annot
+# AnnotationFileTimeStamp 2020/05/04 22:13:27
+# Measure Cortex, NumVert, Number of Vertices, 115827, unitless
+# Measure Cortex, WhiteSurfArea, White Surface Total Area, 83579.2, mm^2
+# Measure Cortex, MeanThickness, Mean Thickness, 2.35815, mm
+# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3
+# Measure BrainSeg, BrainSegVol, Brain Segmentation Volume, 1169408.000000, mm^3
+# Measure BrainSegNotVent, BrainSegVolNotVent, Brain Segmentation Volume Without Ventricles, 1157593.000000, mm^3
+# Measure BrainSegNotVentSurf, BrainSegVolNotVentSurf, Brain Segmentation Volume Without Ventricles from Surf, 1157593.000000, mm^3
+# Measure Cortex, CortexVol, Total cortical gray matter volume, 454587.696158, mm^3
+# Measure SupraTentorial, SupraTentorialVol, Supratentorial volume, 1023873.000000, mm^3
+# Measure SupraTentorialNotVent, SupraTentorialVolNotVent, Supratentorial volume, 1012058.000000, mm^3
+# Measure EstimatedTotalIntraCranialVol, eTIV, Estimated Total Intracranial Volume, 1420434.160521, mm^3
+# NTableCols 10
+# TableCol  1 ColHeader StructName
+# TableCol  1 FieldName Structure Name
+# TableCol  1 Units     NA
+# TableCol  2 ColHeader NumVert
+# TableCol  2 FieldName Number of Vertices
+# TableCol  2 Units     unitless
+# TableCol  3 ColHeader SurfArea
+# TableCol  3 FieldName Surface Area
+# TableCol  3 Units     mm^2
+# TableCol  4 ColHeader GrayVol
+# TableCol  4 FieldName Gray Matter Volume
+# TableCol  4 Units     mm^3
+# TableCol  5 ColHeader ThickAvg 
+# TableCol  5 FieldName Average Thickness
+# TableCol  5 Units     mm
+# TableCol  6 ColHeader ThickStd
+# TableCol  6 FieldName Thickness StdDev
+# TableCol  6 Units     mm 
+# TableCol  7 ColHeader MeanCurv
+# TableCol  7 FieldName Integrated Rectified Mean Curvature
+# TableCol  7 Units     mm^-1
+# TableCol  8 ColHeader GausCurv 
+# TableCol  8 FieldName Integrated Rectified Gaussian Curvature
+# TableCol  8 Units     mm^-2
+# TableCol  9 ColHeader  FoldInd
+# TableCol  9 FieldName  Folding Index 
+# TableCol  9 Units      unitless 
+# TableCol 10 ColHeader CurvInd
+# TableCol 10 FieldName Intrinsic Curvature Index
+# TableCol 10 Units     unitless
+# ColHeaders StructName NumVert SurfArea GrayVol ThickAvg ThickStd MeanCurv GausCurv FoldInd CurvInd
+G_and_S_frontomargin                      629    550   2032  2.720 0.788     0.166     0.052       10     1.2
+G_and_S_occipital_inf                     975    763   2163  2.444 0.589     0.147     0.038       11     1.6
+G_and_S_paracentral                      1394    835   2680  2.611 0.745     0.105     0.027       10     1.6
+G_and_S_subcentral                       1536   1152   3299  2.443 0.554     0.140     0.036       18     2.2
+G_and_S_transv_frontopol                  907    800   3069  2.782 0.672     0.193     0.063       18     2.5
+G_and_S_cingul-Ant                       2731   1859   6291  2.725 0.893     0.112     0.028       23     3.2
+G_and_S_cingul-Mid-Ant                   1359    929   2537  2.656 0.499     0.102     0.019       10     1.1
+G_and_S_cingul-Mid-Post                  1384    950   2911  2.832 0.695     0.109     0.025       11     1.5
+G_cingul-Post-dorsal                      662    483   1901  3.144 0.686     0.161     0.042       10     1.3
+G_cingul-Post-ventral                     338    253    730  2.246 0.712     0.181     0.073        9     1.2
+G_cuneus                                 2360   1719   3295  1.787 0.385     0.154     0.039       30     3.8
+G_front_inf-Opercular                    1288   1002   3363  2.629 0.623     0.145     0.036       19     2.0
+G_front_inf-Orbital                       548    444   1617  2.530 0.595     0.175     0.058        9     1.3
+G_front_inf-Triangul                      771    670   2513  2.796 0.701     0.164     0.053       13     1.8
+G_front_middle                           3623   2949   9520  2.452 0.717     0.160     0.042       58     6.9
+G_front_sup                              6327   4406  17517  3.122 0.624     0.136     0.034       67     9.0
+G_Ins_lg_and_S_cent_ins                   714    477   1398  2.746 1.082     0.146     0.052       12     1.6
+G_insular_short                           595    401   1739  3.161 1.031     0.130     0.047        8     1.1
+G_occipital_middle                       2030   1581   4875  2.546 0.608     0.167     0.043       34     3.8
+G_occipital_sup                          1466   1057   2700  2.140 0.524     0.144     0.032       17     2.1
+G_oc-temp_lat-fusifor                    1279    953   3135  2.478 0.552     0.147     0.038       17     2.2
+G_oc-temp_med-Lingual                    2940   2228   5472  2.122 0.648     0.159     0.045       43     5.9
+G_oc-temp_med-Parahip                     821    524   2280  2.927 0.780     0.103     0.029        7     0.7
+G_orbital                                2675   2119   6867  2.502 0.847     0.177     0.059       63     7.1
+G_pariet_inf-Angular                     2301   1811   4843  2.130 0.585     0.148     0.034       31     3.3
+G_pariet_inf-Supramar                    2075   1709   4618  2.202 0.652     0.165     0.050       37     4.5
+G_parietal_sup                           2717   1947   4965  2.067 0.610     0.134     0.026       28     3.0
+G_postcentral                            2073   1497   3549  1.916 0.506     0.131     0.031       21     2.8
+G_precentral                             2797   1781   6049  2.649 0.595     0.123     0.032       25     4.0
+G_precuneus                              2313   1694   5233  2.406 0.672     0.143     0.032       29     3.2
+G_rectus                                  948    760   2740  2.630 0.712     0.155     0.044       21     1.8
+G_subcallosal                             685    535    979  2.077 0.700     0.185     0.072       12     2.1
+G_temp_sup-G_T_transv                     603    467   1222  2.197 0.633     0.201     0.072       16     1.7
+G_temp_sup-Lateral                       1781   1529   4792  2.337 0.686     0.161     0.052       36     4.4
+G_temp_sup-Plan_polar                     802    581   1895  2.726 0.885     0.127     0.040       11     1.5
+G_temp_sup-Plan_tempo                     578    403   1007  2.117 0.629     0.082     0.013        2     0.3
+G_temporal_inf                           1580   1279   4413  2.583 0.769     0.163     0.049       26     3.4
+G_temporal_middle                        1976   1710   5103  2.266 0.681     0.154     0.045       34     3.9
+Lat_Fis-ant-Horizont                      319    217    386  1.988 0.557     0.105     0.016        2     0.2
+Lat_Fis-ant-Vertical                      177    129    213  1.875 0.358     0.124     0.018        1     0.2
+Lat_Fis-post                             1227    817   1648  2.563 0.494     0.117     0.025        9     1.2
+Pole_occipital                           3047   2381   5167  1.959 0.578     0.168     0.049       47     6.1
+Pole_temporal                            1440   1201   4468  2.576 0.793     0.151     0.039       20     2.7
+S_calcarine                              2581   1785   2885  1.866 0.508     0.127     0.031       24     3.4
+S_central                                2964   1946   3125  1.884 0.509     0.100     0.019       16     2.3
+S_cingul-Marginalis                      1226    813   1665  2.153 0.464     0.094     0.016        6     0.8
+S_circular_insula_ant                     660    430    858  2.313 0.536     0.092     0.016        3     0.4
+S_circular_insula_inf                    1152    748   1588  2.442 0.598     0.087     0.016        5     0.8
+S_circular_insula_sup                    1511    979   2335  2.805 0.582     0.095     0.017        6     1.1
+S_collat_transv_ant                       851    583   1368  2.173 0.754     0.117     0.021        7     0.8
+S_collat_transv_post                      483    348    522  1.976 0.330     0.177     0.045        7     1.0
+S_front_inf                              2322   1663   3565  2.237 0.503     0.122     0.027       19     2.7
+S_front_middle                           1753   1214   2706  2.160 0.713     0.110     0.025       11     1.6
+S_front_sup                              2220   1502   3444  2.387 0.575     0.097     0.018       11     1.7
+S_interm_prim-Jensen                      397    267    468  1.748 0.455     0.092     0.018        2     0.3
+S_intrapariet_and_P_trans                3081   2116   3751  1.948 0.427     0.119     0.023       27     2.9
+S_oc_middle_and_Lunatus                   782    526   1052  2.154 0.493     0.129     0.027        7     0.8
+S_oc_sup_and_transversal                 1313    891   1634  1.980 0.471     0.120     0.025       11     1.4
+S_occipital_ant                           669    492    999  1.938 0.378     0.141     0.037        7     0.9
+S_oc-temp_lat                             711    525   1197  2.072 0.609     0.145     0.037        8     1.2
+S_oc-temp_med_and_Lingual                2057   1356   2710  2.162 0.549     0.101     0.019       11     1.6
+S_orbital_lateral                         432    311    646  2.495 0.537     0.117     0.022        2     0.4
+S_orbital_med-olfact                      800    521    983  2.194 0.641     0.101     0.017        5     0.5
+S_orbital-H_Shaped                       1225    847   2242  2.643 0.661     0.121     0.028       11     1.3
+S_parieto_occipital                      2522   1683   3592  2.339 0.553     0.113     0.020       18     2.2
+S_pericallosal                           1418    958   1775  2.447 0.776     0.139     0.024       18     1.2
+S_postcentral                            2559   1646   2879  1.974 0.442     0.098     0.016       14     1.8
+S_precentral-inf-part                    2059   1380   3182  2.512 0.517     0.111     0.020       13     1.7
+S_precentral-sup-part                    1436    926   1955  2.391 0.480     0.100     0.020        8     1.2
+S_suborbital                              317    207    701  3.280 0.981     0.089     0.011        1     0.2
+S_subparietal                            1160    797   1867  2.508 0.601     0.110     0.024        8     1.0
+S_temporal_inf                            524    383    772  1.917 0.532     0.125     0.029        4     0.6
+S_temporal_sup                           5607   4002   8766  2.175 0.556     0.117     0.025       51     5.8
+S_temporal_transverse                     244    180    338  2.240 0.270     0.135     0.019        2     0.2

--- a/tests/subjects/soichi/stats/rh.aparc.pial.stats
+++ b/tests/subjects/soichi/stats/rh.aparc.pial.stats
@@ -1,0 +1,95 @@
+# Table of FreeSurfer cortical parcellation anatomical statistics 
+# 
+# CreationTime 2020/05/04-22:20:27-GMT
+# generating_program mris_anatomical_stats
+# cvs_version 7.0.0
+# mrisurf.c-cvs_version 7.0.0
+# cmdline mris_anatomical_stats -th3 -mgz -cortex ../label/rh.cortex.label -f ../stats/rh.aparc.pial.stats -b -a ../label/rh.aparc.annot -c ../label/aparc.annot.ctab output rh pial 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# anatomy_type surface
+# subjectname output
+# hemi rh
+# AnnotationFile ../label/rh.aparc.annot
+# AnnotationFileTimeStamp 2020/05/04 21:58:13
+# Measure Cortex, NumVert, Number of Vertices, 115827, unitless
+# Measure Cortex, PialSurfArea, Pial Surface Total Area, 106685, mm^2
+# Measure Cortex, MeanThickness, Mean Thickness, 2.35815, mm
+# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3
+# Measure BrainSeg, BrainSegVol, Brain Segmentation Volume, 1169408.000000, mm^3
+# Measure BrainSegNotVent, BrainSegVolNotVent, Brain Segmentation Volume Without Ventricles, 1157593.000000, mm^3
+# Measure BrainSegNotVentSurf, BrainSegVolNotVentSurf, Brain Segmentation Volume Without Ventricles from Surf, 1157593.000000, mm^3
+# Measure Cortex, CortexVol, Total cortical gray matter volume, 454587.696158, mm^3
+# Measure SupraTentorial, SupraTentorialVol, Supratentorial volume, 1023873.000000, mm^3
+# Measure SupraTentorialNotVent, SupraTentorialVolNotVent, Supratentorial volume, 1012058.000000, mm^3
+# Measure EstimatedTotalIntraCranialVol, eTIV, Estimated Total Intracranial Volume, 1420434.160521, mm^3
+# NTableCols 10
+# TableCol  1 ColHeader StructName
+# TableCol  1 FieldName Structure Name
+# TableCol  1 Units     NA
+# TableCol  2 ColHeader NumVert
+# TableCol  2 FieldName Number of Vertices
+# TableCol  2 Units     unitless
+# TableCol  3 ColHeader SurfArea
+# TableCol  3 FieldName Surface Area
+# TableCol  3 Units     mm^2
+# TableCol  4 ColHeader GrayVol
+# TableCol  4 FieldName Gray Matter Volume
+# TableCol  4 Units     mm^3
+# TableCol  5 ColHeader ThickAvg 
+# TableCol  5 FieldName Average Thickness
+# TableCol  5 Units     mm
+# TableCol  6 ColHeader ThickStd
+# TableCol  6 FieldName Thickness StdDev
+# TableCol  6 Units     mm 
+# TableCol  7 ColHeader MeanCurv
+# TableCol  7 FieldName Integrated Rectified Mean Curvature
+# TableCol  7 Units     mm^-1
+# TableCol  8 ColHeader GausCurv 
+# TableCol  8 FieldName Integrated Rectified Gaussian Curvature
+# TableCol  8 Units     mm^-2
+# TableCol  9 ColHeader  FoldInd
+# TableCol  9 FieldName  Folding Index 
+# TableCol  9 Units      unitless 
+# TableCol 10 ColHeader CurvInd
+# TableCol 10 FieldName Intrinsic Curvature Index
+# TableCol 10 Units     unitless
+# ColHeaders StructName NumVert SurfArea GrayVol ThickAvg ThickStd MeanCurv GausCurv FoldInd CurvInd
+bankssts                                 1094    826   1725  2.215 0.544     0.136     0.034       17     1.5
+caudalanteriorcingulate                  1137    938   2327  2.842 0.667     0.188     0.051       65     2.2
+caudalmiddlefrontal                      3126   2625   5978  2.447 0.605     0.142     0.034       40     4.4
+cuneus                                   2446   2141   3537  1.886 0.407     0.156     0.041       37     4.2
+entorhinal                                448    689   1599  3.171 0.707     0.291     0.075        9     1.9
+fusiform                                 3194   3044   6223  2.315 0.635     0.176     0.049       81     6.5
+inferiorparietal                         7290   7098  13619  2.161 0.568     0.170     0.038      136    12.1
+inferiortemporal                         2872   3289   6636  2.380 0.757     0.205     0.050       56     6.3
+isthmuscingulate                         1455   1356   2785  2.351 0.673     0.195     0.074      131     4.6
+lateraloccipital                         6205   5533  10849  2.162 0.568     0.171     0.048      375    11.1
+lateralorbitofrontal                     3755   3379   7526  2.476 0.734     0.181     0.050      135     8.3
+lingual                                  4863   4381   8074  2.098 0.596     0.161     0.045      101     8.8
+medialorbitofrontal                      3103   3228   7261  2.644 0.956     0.192     0.074      109     6.9
+middletemporal                           3518   4471   7625  2.212 0.647     0.206     0.046       61     7.3
+parahippocampal                           888    870   1675  2.425 0.763     0.223     0.070       19     3.0
+paracentral                              2315   1629   4190  2.762 0.727     0.105     0.024       24     2.3
+parsopercularis                          2127   1923   4214  2.456 0.669     0.177     0.054       54     4.8
+parsorbitalis                            1076   1159   2404  2.526 0.734     0.182     0.045       22     1.7
+parstriangularis                         2087   2311   4946  2.468 0.676     0.189     0.042       35     3.9
+pericalcarine                            2258   1401   2304  1.634 0.414     0.120     0.036       52     2.8
+postcentral                              5861   5150   8849  1.960 0.561     0.142     0.032       83     8.1
+posteriorcingulate                       1769   1548   3777  2.662 0.781     0.190     0.058      132     3.7
+precentral                               7650   5694  13170  2.460 0.581     0.122     0.031      126     9.9
+precuneus                                5751   4425  10004  2.406 0.595     0.143     0.037      142     8.7
+rostralanteriorcingulate                  827   1085   2414  2.889 0.686     0.212     0.045       16     2.0
+rostralmiddlefrontal                     7032   7493  15442  2.365 0.687     0.193     0.046      152    14.1
+superiorfrontal                          9449   8503  22074  2.877 0.688     0.154     0.039      178    14.9
+superiorparietal                         7647   6387  11973  2.044 0.551     0.140     0.033      110     9.8
+superiortemporal                         5052   5097  10104  2.320 0.650     0.198     0.055      124    12.4
+supramarginal                            4621   4386   8461  2.207 0.616     0.176     0.046      101     8.2
+frontalpole                               372    623   1574  3.211 0.790     0.258     0.052        7     0.9
+temporalpole                              582    906   2030  3.120 0.834     0.295     0.080       17     2.1
+transversetemporal                        538    608    998  2.060 0.552     0.236     0.062       22     1.4
+insula                                   3419   2492   6398  2.765 0.876     0.188     0.062       96    10.0

--- a/tests/subjects/soichi/stats/rh.aparc.stats
+++ b/tests/subjects/soichi/stats/rh.aparc.stats
@@ -1,0 +1,95 @@
+# Table of FreeSurfer cortical parcellation anatomical statistics 
+# 
+# CreationTime 2020/05/04-22:20:26-GMT
+# generating_program mris_anatomical_stats
+# cvs_version 7.0.0
+# mrisurf.c-cvs_version 7.0.0
+# cmdline mris_anatomical_stats -th3 -mgz -cortex ../label/rh.cortex.label -f ../stats/rh.aparc.stats -b -a ../label/rh.aparc.annot -c ../label/aparc.annot.ctab output rh white 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# anatomy_type surface
+# subjectname output
+# hemi rh
+# AnnotationFile ../label/rh.aparc.annot
+# AnnotationFileTimeStamp 2020/05/04 21:58:13
+# Measure Cortex, NumVert, Number of Vertices, 115827, unitless
+# Measure Cortex, WhiteSurfArea, White Surface Total Area, 83579.2, mm^2
+# Measure Cortex, MeanThickness, Mean Thickness, 2.35815, mm
+# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3
+# Measure BrainSeg, BrainSegVol, Brain Segmentation Volume, 1169408.000000, mm^3
+# Measure BrainSegNotVent, BrainSegVolNotVent, Brain Segmentation Volume Without Ventricles, 1157593.000000, mm^3
+# Measure BrainSegNotVentSurf, BrainSegVolNotVentSurf, Brain Segmentation Volume Without Ventricles from Surf, 1157593.000000, mm^3
+# Measure Cortex, CortexVol, Total cortical gray matter volume, 454587.696158, mm^3
+# Measure SupraTentorial, SupraTentorialVol, Supratentorial volume, 1023873.000000, mm^3
+# Measure SupraTentorialNotVent, SupraTentorialVolNotVent, Supratentorial volume, 1012058.000000, mm^3
+# Measure EstimatedTotalIntraCranialVol, eTIV, Estimated Total Intracranial Volume, 1420434.160521, mm^3
+# NTableCols 10
+# TableCol  1 ColHeader StructName
+# TableCol  1 FieldName Structure Name
+# TableCol  1 Units     NA
+# TableCol  2 ColHeader NumVert
+# TableCol  2 FieldName Number of Vertices
+# TableCol  2 Units     unitless
+# TableCol  3 ColHeader SurfArea
+# TableCol  3 FieldName Surface Area
+# TableCol  3 Units     mm^2
+# TableCol  4 ColHeader GrayVol
+# TableCol  4 FieldName Gray Matter Volume
+# TableCol  4 Units     mm^3
+# TableCol  5 ColHeader ThickAvg 
+# TableCol  5 FieldName Average Thickness
+# TableCol  5 Units     mm
+# TableCol  6 ColHeader ThickStd
+# TableCol  6 FieldName Thickness StdDev
+# TableCol  6 Units     mm 
+# TableCol  7 ColHeader MeanCurv
+# TableCol  7 FieldName Integrated Rectified Mean Curvature
+# TableCol  7 Units     mm^-1
+# TableCol  8 ColHeader GausCurv 
+# TableCol  8 FieldName Integrated Rectified Gaussian Curvature
+# TableCol  8 Units     mm^-2
+# TableCol  9 ColHeader  FoldInd
+# TableCol  9 FieldName  Folding Index 
+# TableCol  9 Units      unitless 
+# TableCol 10 ColHeader CurvInd
+# TableCol 10 FieldName Intrinsic Curvature Index
+# TableCol 10 Units     unitless
+# ColHeaders StructName NumVert SurfArea GrayVol ThickAvg ThickStd MeanCurv GausCurv FoldInd CurvInd
+bankssts                                 1094    757   1725  2.215 0.544     0.109     0.025        9     1.1
+caudalanteriorcingulate                  1137    780   2327  2.842 0.667     0.116     0.021       11     1.0
+caudalmiddlefrontal                      3126   2218   5978  2.447 0.605     0.122     0.024       28     3.1
+cuneus                                   2446   1781   3537  1.886 0.407     0.151     0.038       30     4.0
+entorhinal                                448    310   1599  3.171 0.707     0.103     0.028        3     0.5
+fusiform                                 3194   2330   6223  2.315 0.635     0.134     0.032       36     4.5
+inferiorparietal                         7290   5467  13619  2.161 0.568     0.135     0.030       86     9.4
+inferiortemporal                         2872   2203   6636  2.380 0.757     0.148     0.040       39     4.9
+isthmuscingulate                         1455   1085   2785  2.351 0.673     0.157     0.046       24     2.8
+lateraloccipital                         6205   4673  10849  2.162 0.568     0.160     0.042       84    10.6
+lateralorbitofrontal                     3755   2748   7526  2.476 0.734     0.144     0.042       58     6.7
+lingual                                  4863   3579   8074  2.098 0.596     0.146     0.040       63     8.5
+medialorbitofrontal                      3103   2244   7261  2.644 0.956     0.130     0.035       39     4.5
+middletemporal                           3518   2821   7625  2.212 0.647     0.136     0.035       46     5.5
+parahippocampal                           888    572   1675  2.425 0.763     0.092     0.020        5     0.6
+paracentral                              2315   1388   4190  2.762 0.727     0.097     0.023       14     2.2
+parsopercularis                          2127   1536   4214  2.456 0.669     0.128     0.028       23     2.6
+parsorbitalis                            1076    833   2404  2.526 0.734     0.148     0.035       15     1.6
+parstriangularis                         2087   1628   4946  2.468 0.676     0.140     0.040       25     3.6
+pericalcarine                            2258   1599   2304  1.634 0.414     0.143     0.037       25     3.4
+postcentral                              5861   4070   8849  1.960 0.561     0.114     0.025       48     6.2
+posteriorcingulate                       1769   1269   3777  2.662 0.781     0.138     0.029       22     2.2
+precentral                               7650   5005  13170  2.460 0.581     0.116     0.027       58     8.8
+precuneus                                5751   3950  10004  2.406 0.595     0.119     0.025       49     5.9
+rostralanteriorcingulate                  827    643   2414  2.889 0.686     0.147     0.038       12     1.6
+rostralmiddlefrontal                     7032   5486  15442  2.365 0.687     0.144     0.038       87    11.6
+superiorfrontal                          9449   6512  22074  2.877 0.688     0.120     0.028       79    10.7
+superiorparietal                         7647   5342  11973  2.044 0.551     0.125     0.025       72     7.6
+superiortemporal                         5052   3778  10104  2.320 0.650     0.128     0.034       63     7.8
+supramarginal                            4621   3486   8461  2.207 0.616     0.140     0.036       56     7.4
+frontalpole                               372    342   1574  3.211 0.790     0.202     0.072        9     1.1
+temporalpole                              582    460   2030  3.120 0.834     0.147     0.042        8     1.1
+transversetemporal                        538    427    998  2.060 0.552     0.190     0.069       14     1.5
+insula                                   3419   2257   6398  2.765 0.876     0.129     0.041       44     6.1

--- a/tests/subjects/soichi/stats/rh.curv.stats
+++ b/tests/subjects/soichi/stats/rh.curv.stats
@@ -1,0 +1,220 @@
+
+Raw <mean> +- <std> (using 'rh.curv'):                -0.02333 +- 0.1622 
+       Raw Min:                                       -0.77579 at vertex 56974   
+       Raw Max:                                        0.59334 at vertex 110994  
+       Raw Curvature Calculation Type:                discrete
+       Raw Mean Vertex Separation (Whole Surface):     0.86393 +- 0.15562 mm
+       Raw Total Surface Area:                     79575.77344 mm^2
+       Raw Total Number of Vertices:                    124680
+       Raw Average Vertex Area (Whole Surface):        0.63824 mm^2
+       Raw Natural Surface Integral:               -2091.56201
+       Raw Rectified Surface Integral:             10201.73438
+       Raw Positive Surface Integral:               4055.08618
+       Raw Negative Surface Integral:               6146.64844
+       Raw Mean Natural Surface Integral:             -0.01678 across 124680 (100.00%) vertices
+       Raw Mean Rectified Surface Integral:            0.08182 across 124680 (100.00%) vertices
+       Raw Mean Positive Surface Integral:             0.06807 across 59569 (47.78%) vertices
+       Raw Mean Negative Surface Integral:             0.09440 across 65111 (52.22%) vertices
+       Raw AreaNorm Natural Surface Integral:         -0.02628 across 79575.406250 (100.00%) mm^2
+       Raw AreaNorm Rectified Surface Integral:        0.12820 across 79575.406250 (100.00%) mm^2
+       Raw AreaNorm Positive Surface Integral:         0.11049 across 36700.890625 (46.12%) mm^2
+       Raw AreaNorm Negative Surface Integral:         0.14336 across 42874.558594 (53.88%) mm^2
+
+Raw <mean> +- <std> (using 'rh.sulc'):                -0.00000 +- 5.7108 
+       Raw Min:                                      -13.83525 at vertex 79666   
+       Raw Max:                                       16.78419 at vertex 45579   
+       Raw Curvature Calculation Type:                discrete
+       Raw Mean Vertex Separation (Whole Surface):     0.86393 +- 0.15562 mm
+       Raw Total Surface Area:                     79575.77344 mm^2
+       Raw Total Number of Vertices:                    124680
+       Raw Average Vertex Area (Whole Surface):        0.63824 mm^2
+       Raw Natural Surface Integral:              -19823.66602
+       Raw Rectified Surface Integral:            370965.00000
+       Raw Positive Surface Integral:             175570.67188
+       Raw Negative Surface Integral:             195394.34375
+       Raw Mean Natural Surface Integral:             -0.15900 across 124680 (100.00%) vertices
+       Raw Mean Rectified Surface Integral:            2.97534 across 124680 (100.00%) vertices
+       Raw Mean Positive Surface Integral:             2.99353 across 58650 (47.04%) vertices
+       Raw Mean Negative Surface Integral:             2.95918 across 66030 (52.96%) vertices
+       Raw AreaNorm Natural Surface Integral:         -0.24912 across 79575.406250 (100.00%) mm^2
+       Raw AreaNorm Rectified Surface Integral:        4.66180 across 79575.406250 (100.00%) mm^2
+       Raw AreaNorm Positive Surface Integral:         4.91655 across 35710.144531 (44.88%) mm^2
+       Raw AreaNorm Negative Surface Integral:         4.45443 across 43865.214844 (55.12%) mm^2
+
+K <mean> +- <std> (using 'rh.smoothwm'):               0.02740 +- 1.0966 mm^-2
+         K Min:                                       -6.96519 at vertex 102918  
+         K Max:                                      194.38727 at vertex 102124  
+         K Curvature Calculation Type:                discrete
+         K Mean Vertex Separation (Whole Surface):     0.86393 +- 0.15562 mm
+         K Total Surface Area:                     79575.77344 mm^2
+         K Total Number of Vertices:                    124680
+         K Average Vertex Area (Whole Surface):        0.63824 mm^2
+         K Natural Surface Integral:                  10.15505
+         K Rectified Surface Integral:              3708.86279
+         K Positive Surface Integral:               1859.50891
+         K Negative Surface Integral:               1849.35388
+         K Mean Natural Surface Integral:              0.00008 across 124680 (100.00%) vertices
+         K Mean Rectified Surface Integral:            0.02975 across 124680 (100.00%) vertices
+         K Mean Positive Surface Integral:             0.03242 across 57365 (46.01%) vertices
+         K Mean Negative Surface Integral:             0.02747 across 67315 (53.99%) vertices
+         K AreaNorm Natural Surface Integral:          0.00013 across 79575.406250 (100.00%) mm^2
+         K AreaNorm Rectified Surface Integral:        0.04661 across 79575.406250 (100.00%) mm^2
+         K AreaNorm Positive Surface Integral:         0.05666 across 32818.390625 (41.24%) mm^2
+         K AreaNorm Negative Surface Integral:         0.03955 across 46756.988281 (58.76%) mm^2
+
+H <mean> +- <std> (using 'rh.smoothwm'):              -0.03726 +- 0.3389 mm^-1
+         H Min:                                      -17.35979 at vertex 102124  
+         H Max:                                        9.68358 at vertex 68281   
+         H Curvature Calculation Type:                discrete
+         H Mean Vertex Separation (Whole Surface):     0.86393 +- 0.15562 mm
+         H Total Surface Area:                     79575.77344 mm^2
+         H Total Number of Vertices:                    124680
+         H Average Vertex Area (Whole Surface):        0.63824 mm^2
+         H Natural Surface Integral:               -1803.74194
+         H Rectified Surface Integral:             13666.22559
+         H Positive Surface Integral:               5931.24219
+         H Negative Surface Integral:               7734.98389
+         H Mean Natural Surface Integral:             -0.01447 across 124680 (100.00%) vertices
+         H Mean Rectified Surface Integral:            0.10961 across 124680 (100.00%) vertices
+         H Mean Positive Surface Integral:             0.09121 across 65026 (52.15%) vertices
+         H Mean Negative Surface Integral:             0.12966 across 59654 (47.85%) vertices
+         H AreaNorm Natural Surface Integral:         -0.02267 across 79575.406250 (100.00%) mm^2
+         H AreaNorm Rectified Surface Integral:        0.17174 across 79575.406250 (100.00%) mm^2
+         H AreaNorm Positive Surface Integral:         0.14264 across 41582.054688 (52.25%) mm^2
+         H AreaNorm Negative Surface Integral:         0.20359 across 37993.140625 (47.74%) mm^2
+
+k1 <mean> +- <std> (using 'rh.smoothwm'):             -0.07581 +- 0.6173 mm^-1
+        k1 Min:                                      -28.16885 at vertex 56974   
+        k1 Max:                                       18.63453 at vertex 68281   
+        k1 Curvature Calculation Type:                discrete
+        k1 Mean Vertex Separation (Whole Surface):     0.86393 +- 0.15562 mm
+        k1 Total Surface Area:                     79575.77344 mm^2
+        k1 Total Number of Vertices:                    124680
+        k1 Average Vertex Area (Whole Surface):        0.63824 mm^2
+        k1 Natural Surface Integral:               -3975.01392
+        k1 Rectified Surface Integral:             28891.44336
+        k1 Positive Surface Integral:              12458.21484
+        k1 Negative Surface Integral:              16433.22852
+        k1 Mean Natural Surface Integral:             -0.03188 across 124680 (100.00%) vertices
+        k1 Mean Rectified Surface Integral:            0.23172 across 124680 (100.00%) vertices
+        k1 Mean Positive Surface Integral:             0.19159 across 65026 (52.15%) vertices
+        k1 Mean Negative Surface Integral:             0.27548 across 59654 (47.85%) vertices
+        k1 AreaNorm Natural Surface Integral:         -0.04995 across 79575.406250 (100.00%) mm^2
+        k1 AreaNorm Rectified Surface Integral:        0.36307 across 79575.406250 (100.00%) mm^2
+        k1 AreaNorm Positive Surface Integral:         0.29961 across 41582.054688 (52.25%) mm^2
+        k1 AreaNorm Negative Surface Integral:         0.43253 across 37993.140625 (47.74%) mm^2
+
+k2 <mean> +- <std> (using 'rh.smoothwm'):              0.00129 +- 0.1529 mm^-1
+        k2 Min:                                       -7.01692 at vertex 102124  
+        k2 Max:                                        2.92109 at vertex 63224   
+        k2 Curvature Calculation Type:                discrete
+        k2 Mean Vertex Separation (Whole Surface):     0.86393 +- 0.15562 mm
+        k2 Total Surface Area:                     79575.77344 mm^2
+        k2 Total Number of Vertices:                    124680
+        k2 Average Vertex Area (Whole Surface):        0.63824 mm^2
+        k2 Natural Surface Integral:                 367.53009
+        k2 Rectified Surface Integral:              7075.75635
+        k2 Positive Surface Integral:               3721.64331
+        k2 Negative Surface Integral:               3354.11328
+        k2 Mean Natural Surface Integral:              0.00295 across 124680 (100.00%) vertices
+        k2 Mean Rectified Surface Integral:            0.05675 across 124680 (100.00%) vertices
+        k2 Mean Positive Surface Integral:             0.05690 across 65403 (52.46%) vertices
+        k2 Mean Negative Surface Integral:             0.05658 across 59277 (47.54%) vertices
+        k2 AreaNorm Natural Surface Integral:          0.00462 across 79575.406250 (100.00%) mm^2
+        k2 AreaNorm Rectified Surface Integral:        0.08892 across 79575.406250 (100.00%) mm^2
+        k2 AreaNorm Positive Surface Integral:         0.08966 across 41508.031250 (52.16%) mm^2
+        k2 AreaNorm Negative Surface Integral:         0.08811 across 38067.277344 (47.84%) mm^2
+
+S <mean> +- <std> (using 'rh.smoothwm'):               0.35543 +- 3.1383 mm^-2
+         S Min:                                        0.00000 at vertex 136     
+         S Max:                                      476.08676 at vertex 56974   
+         S Curvature Calculation Type:                discrete
+         S Mean Vertex Separation (Whole Surface):     0.86393 +- 0.15562 mm
+         S Total Surface Area:                     79575.77344 mm^2
+         S Total Number of Vertices:                    124680
+         S Average Vertex Area (Whole Surface):        0.63824 mm^2
+         S Natural Surface Integral:               20223.72461
+         S Rectified Surface Integral:             20223.72461
+         S Positive Surface Integral:              20223.72461
+         S Negative Surface Integral:                  0.00000
+         S Mean Natural Surface Integral:              0.16221 across 124680 (100.00%) vertices
+         S Mean Rectified Surface Integral:            0.16221 across 124680 (100.00%) vertices
+         S Mean Positive Surface Integral:             0.16221 across 124680 (100.00%) vertices
+         S Mean Negative Surface Integral:             0.00000 across 0 (00.00%) vertices
+         S AreaNorm Natural Surface Integral:          0.25415 across 79575.406250 (100.00%) mm^2
+         S AreaNorm Rectified Surface Integral:        0.25415 across 79575.406250 (100.00%) mm^2
+         S AreaNorm Positive Surface Integral:         0.25415 across 79575.406250 (100.00%) mm^2
+         S AreaNorm Negative Surface Integral:         0.00000 across 0.000000 (00.00%) mm^2
+
+C <mean> +- <std> (using 'rh.smoothwm'):               0.30960 +- 0.3305 mm^-2
+         C Min:                                        0.00615 at vertex 27000   
+         C Max:                                       20.41812 at vertex 56974   
+         C Curvature Calculation Type:                discrete
+         C Mean Vertex Separation (Whole Surface):     0.86393 +- 0.15562 mm
+         C Total Surface Area:                     79575.77344 mm^2
+         C Total Number of Vertices:                    124680
+         C Average Vertex Area (Whole Surface):        0.63824 mm^2
+         C Natural Surface Integral:               21428.21484
+         C Rectified Surface Integral:             21428.21484
+         C Positive Surface Integral:              21428.21484
+         C Negative Surface Integral:                  0.00000
+         C Mean Natural Surface Integral:              0.17187 across 124680 (100.00%) vertices
+         C Mean Rectified Surface Integral:            0.17187 across 124680 (100.00%) vertices
+         C Mean Positive Surface Integral:             0.17187 across 124680 (100.00%) vertices
+         C Mean Negative Surface Integral:             0.00000 across 0 (00.00%) vertices
+         C AreaNorm Natural Surface Integral:          0.26928 across 79575.406250 (100.00%) mm^2
+         C AreaNorm Rectified Surface Integral:        0.26928 across 79575.406250 (100.00%) mm^2
+         C AreaNorm Positive Surface Integral:         0.26928 across 79575.406250 (100.00%) mm^2
+         C AreaNorm Negative Surface Integral:         0.00000 across 0.000000 (00.00%) mm^2
+
+BE <mean> +- <std> (using 'rh.smoothwm'):              0.41019 +- 5.1732 mm^-2
+        BE Min:                                        0.00008 at vertex 27000   
+        BE Max:                                      833.79956 at vertex 56974   
+        BE Curvature Calculation Type:                discrete
+        BE Mean Vertex Separation (Whole Surface):     0.86393 +- 0.15562 mm
+        BE Total Surface Area:                     79575.77344 mm^2
+        BE Total Number of Vertices:                    124680
+        BE Average Vertex Area (Whole Surface):        0.63824 mm^2
+        BE Natural Surface Integral:               20243.11133
+        BE Rectified Surface Integral:             20243.11133
+        BE Positive Surface Integral:              20243.11133
+        BE Negative Surface Integral:                  0.00000
+        BE Mean Natural Surface Integral:              0.16236 across 124680 (100.00%) vertices
+        BE Mean Rectified Surface Integral:            0.16236 across 124680 (100.00%) vertices
+        BE Mean Positive Surface Integral:             0.16236 across 124680 (100.00%) vertices
+        BE Mean Negative Surface Integral:             0.00000 across 0 (00.00%) vertices
+        BE AreaNorm Natural Surface Integral:          0.25439 across 79575.406250 (100.00%) mm^2
+        BE AreaNorm Rectified Surface Integral:        0.25439 across 79575.406250 (100.00%) mm^2
+        BE AreaNorm Positive Surface Integral:         0.25439 across 79575.406250 (100.00%) mm^2
+        BE AreaNorm Negative Surface Integral:         0.00000 across 0.000000 (00.00%) mm^2
+
+FI <mean> +- <std> (using 'rh.smoothwm'):              0.31279 +- 3.8860 mm^-2
+        FI Min:                                        0.00000 at vertex 136     
+        FI Max:                                      614.62775 at vertex 56974   
+        FI Curvature Calculation Type:                discrete
+        FI Mean Vertex Separation (Whole Surface):     0.86393 +- 0.15562 mm
+        FI Total Surface Area:                     79575.77344 mm^2
+        FI Total Number of Vertices:                    124680
+        FI Average Vertex Area (Whole Surface):        0.63824 mm^2
+        FI Natural Surface Integral:               15214.53516
+        FI Rectified Surface Integral:             15214.53516
+        FI Positive Surface Integral:              15214.53516
+        FI Negative Surface Integral:                  0.00000
+        FI Mean Natural Surface Integral:              0.12203 across 124680 (100.00%) vertices
+        FI Mean Rectified Surface Integral:            0.12203 across 124680 (100.00%) vertices
+        FI Mean Positive Surface Integral:             0.12203 across 124680 (100.00%) vertices
+        FI Mean Negative Surface Integral:             0.00000 across 0 (00.00%) vertices
+        FI AreaNorm Natural Surface Integral:          0.19120 across 79575.406250 (100.00%) mm^2
+        FI AreaNorm Rectified Surface Integral:        0.19120 across 79575.406250 (100.00%) mm^2
+        FI AreaNorm Positive Surface Integral:         0.19120 across 79575.406250 (100.00%) mm^2
+        FI AreaNorm Negative Surface Integral:         0.00000 across 0.000000 (00.00%) mm^2
+
+curv -- calculation type:                                discrete
+curv -- Folding Index (FI):                            1210.73425
+curv -- Intrinsic Curvature Index - positive (ICIp):    147.97502
+curv -- Intrinsic Curvature Index - negative (ICIn):    147.16690
+curv -- Intrinsic Curvature Index - natural  (ICIt):      0.80811
+
+Mean across 10 curvatures: 1.2803e-01 +- 1.8243e-01
+
+

--- a/tests/subjects/soichi/stats/rh.w-g.pct.stats
+++ b/tests/subjects/soichi/stats/rh.w-g.pct.stats
@@ -1,0 +1,92 @@
+# Title Segmentation Statistics 
+# 
+# generating_program mri_segstats
+# cvs_version 7.0.0
+# cmdline mri_segstats --in /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f/output/surf/rh.w-g.pct.mgh --annot output rh aparc --sum /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f/output/stats/rh.w-g.pct.stats --snr 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# anatomy_type surface
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# subjectname output
+# Annot output rh aparc
+# ColorTable /tmp/mri_segstats.tmp.output.rh.176.ctab 
+# ColorTableTimeStamp 2020/05/04 22:13:42 
+# InVolFile  /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f/output/surf/rh.w-g.pct.mgh 
+# InVolFileTimeStamp  2020/05/04 22:13:41 
+# InVolFrame 0 
+# Only reporting non-empty segmentations
+# VertexArea_mm2 0.713817 
+# TableCol  1 ColHeader Index 
+# TableCol  1 FieldName Index 
+# TableCol  1 Units     NA 
+# TableCol  2 ColHeader SegId 
+# TableCol  2 FieldName Segmentation Id
+# TableCol  2 Units     NA
+# TableCol  3 ColHeader NVertices 
+# TableCol  3 FieldName Number of Vertices
+# TableCol  3 Units     unitless
+# TableCol  4 ColHeader Area_mm2
+# TableCol  4 FieldName Area
+# TableCol  4 Units     mm^2
+# TableCol  5 ColHeader StructName
+# TableCol  5 FieldName Structure Name
+# TableCol  5 Units     NA
+# TableCol  6 ColHeader Mean 
+# TableCol  6 FieldName Intensity Mean
+# TableCol  6 Units     unknown
+# TableCol  7 ColHeader StdDev
+# TableCol  7 FieldName Itensity StdDev
+# TableCol  7 Units     unknown
+# TableCol  8 ColHeader Min
+# TableCol  8 FieldName Intensity Min
+# TableCol  8 Units     unknown
+# TableCol  9 ColHeader Max
+# TableCol  9 FieldName Intensity Max
+# TableCol  9 Units     unknown
+# TableCol 10 ColHeader Range
+# TableCol 10 FieldName Intensity Range
+# TableCol 10 Units     unknown
+# TableCol 11 ColHeader SNR
+# TableCol 11 FieldName Intensity SNR
+# TableCol 11 Units     none
+# NRows 35 
+# NTableCols 11 
+# ColHeaders  Index SegId NVertices Area_mm2 StructName Mean StdDev Min Max Range SNR  
+  1 2000      8853     5420.3  unknown                            0.0000     0.0000     0.0000     0.0000     0.0000       -nan 
+  2 2001      1094      756.7  bankssts                          31.2677     7.1936    -1.4849    50.0722    51.5571     4.3466 
+  3 2002      1137      779.6  caudalanteriorcingulate           30.7286     7.7858     7.1339    50.1157    42.9818     3.9468 
+  4 2003      3126     2217.6  caudalmiddlefrontal               29.0918     6.1220     3.0490    48.5092    45.4603     4.7520 
+  5 2005      2446     1781.0  cuneus                            24.3815     5.9971     3.7057    41.9099    38.2042     4.0655 
+  6 2006       448      310.1  entorhinal                        29.2989     7.7223    -3.7783    54.4055    58.1838     3.7941 
+  7 2007      3194     2329.9  fusiform                          28.7824     7.7527    -9.2600    52.1709    61.4310     3.7126 
+  8 2008      7290     5466.7  inferiorparietal                  29.2785     7.0142   -26.9370    57.2965    84.2335     4.1742 
+  9 2009      2872     2202.8  inferiortemporal                  30.1240     8.4380     0.6067    55.0641    54.4574     3.5700 
+ 10 2010      1455     1084.6  isthmuscingulate                  24.6425     8.0622    -6.1244    56.7026    62.8269     3.0566 
+ 11 2011      6205     4673.5  lateraloccipital                  26.6143     7.6781    -9.8784    56.7037    66.5822     3.4663 
+ 12 2012      3755     2748.3  lateralorbitofrontal              28.4431    11.1385   -52.8371    74.9205   127.7576     2.5536 
+ 13 2013      4863     3579.3  lingual                           23.9671     8.3827   -57.4021    45.5011   102.9032     2.8591 
+ 14 2014      3103     2244.0  medialorbitofrontal               28.9179    11.5042   -56.8839    54.1360   111.0199     2.5137 
+ 15 2015      3518     2820.8  middletemporal                    27.5033     7.7895    -9.8213    54.8879    64.7092     3.5308 
+ 16 2016       888      571.8  parahippocampal                   30.4945     7.8268    -1.3078    63.7504    65.0582     3.8961 
+ 17 2017      2315     1388.4  paracentral                       24.0975     8.5854    -0.1541    42.9093    43.0634     2.8068 
+ 18 2018      2127     1536.2  parsopercularis                   30.6128     7.3398   -10.2121    53.0001    63.2122     4.1708 
+ 19 2019      1076      832.6  parsorbitalis                     28.4238     7.5325     2.9583    51.4170    48.4587     3.7735 
+ 20 2020      2087     1627.5  parstriangularis                  28.4401     7.1978     1.5305    54.2725    52.7420     3.9512 
+ 21 2021      2258     1599.5  pericalcarine                     22.1914     5.8634    -0.6005    38.1512    38.7517     3.7847 
+ 22 2022      5861     4069.8  postcentral                       26.5326     6.3235    -6.1775    52.9131    59.0906     4.1959 
+ 23 2023      1769     1269.1  posteriorcingulate                29.5282     9.0183     4.1041    56.4376    52.3334     3.2743 
+ 24 2024      7650     5005.2  precentral                        24.8604     7.6613    -9.0372    56.5383    65.5754     3.2449 
+ 25 2025      5751     3949.9  precuneus                         29.1653     6.5867     2.7738    56.3786    53.6048     4.4279 
+ 26 2026       827      643.2  rostralanteriorcingulate          28.5428     7.9780     5.7940    59.9231    54.1290     3.5777 
+ 27 2027      7032     5486.2  rostralmiddlefrontal              28.8678     7.3535    -8.7395    50.9992    59.7387     3.9257 
+ 28 2028      9449     6511.7  superiorfrontal                   30.5148     6.8143     3.1892    55.3544    52.1653     4.4780 
+ 29 2029      7647     5341.8  superiorparietal                  28.2989     5.9352    -4.5147    47.7949    52.3096     4.7680 
+ 30 2030      5052     3777.7  superiortemporal                  29.3703     8.2497   -56.9813    64.5267   121.5080     3.5602 
+ 31 2031      4621     3486.1  supramarginal                     29.2036     7.8452   -28.3112    53.0074    81.3186     3.7225 
+ 32 2032       372      341.7  frontalpole                       29.1104     8.2514     9.4101    49.6567    40.2466     3.5279 
+ 33 2033       582      460.2  temporalpole                      27.7395     9.2680   -12.6508    54.7236    67.3745     2.9930 
+ 34 2034       538      427.5  transversetemporal                22.7135     9.2696   -37.0885    53.3634    90.4520     2.4503 
+ 35 2035      3419     2257.4  insula                            25.0075    14.1123   -69.1953    96.5754   165.7708     1.7720 

--- a/tests/subjects/soichi/stats/wmparc.stats
+++ b/tests/subjects/soichi/stats/wmparc.stats
@@ -1,0 +1,135 @@
+# Title Segmentation Statistics 
+# 
+# generating_program mri_segstats
+# cvs_version 7.0.0
+# cmdline mri_segstats --seed 1234 --seg mri/wmparc.mgz --sum stats/wmparc.stats --pv mri/norm.mgz --excludeid 0 --brainmask mri/brainmask.mgz --in mri/norm.mgz --in-intensity-name norm --in-intensity-units MR --subject output --surf-wm-vol --ctab /usr/local/freesurfer/WMParcStatsLUT.txt --etiv 
+# sysname  Linux
+# hostname nid00762
+# machine  x86_64
+# user     hayashis
+# anatomy_type volume
+# 
+# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
+# subjectname output
+# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3
+# Measure VentricleChoroidVol, VentricleChoroidVol, Volume of ventricles and choroid plexus, 9296.000000, mm^3
+# Measure lhCerebralWhiteMatter, lhCerebralWhiteMatterVol, Left hemisphere cerebral white matter volume, 251589.500000, mm^3
+# Measure rhCerebralWhiteMatter, rhCerebralWhiteMatterVol, Right hemisphere cerebral white matter volume, 244895.500000, mm^3
+# Measure CerebralWhiteMatter, CerebralWhiteMatterVol, Total cerebral white matter volume, 496485.000000, mm^3
+# Measure Mask, MaskVol, Mask Volume, 1686052.000000, mm^3
+# Measure EstimatedTotalIntraCranialVol, eTIV, Estimated Total Intracranial Volume, 1420434.160521, mm^3
+# SegVolFile mri/wmparc.mgz 
+# SegVolFileTimeStamp  2020/05/04 22:17:18 
+# ColorTable /usr/local/freesurfer/WMParcStatsLUT.txt 
+# ColorTableTimeStamp 2020/04/29 22:19:19 
+# InVolFile  mri/norm.mgz 
+# InVolFileTimeStamp  2020/05/04 19:28:46 
+# InVolFrame 0 
+# PVVolFile  mri/norm.mgz 
+# PVVolFileTimeStamp  2020/05/04 19:28:46 
+# ExcludeSegId 0 
+# Only reporting non-empty segmentations
+# VoxelVolume_mm3 1 
+# TableCol  1 ColHeader Index 
+# TableCol  1 FieldName Index 
+# TableCol  1 Units     NA 
+# TableCol  2 ColHeader SegId 
+# TableCol  2 FieldName Segmentation Id
+# TableCol  2 Units     NA
+# TableCol  3 ColHeader NVoxels 
+# TableCol  3 FieldName Number of Voxels
+# TableCol  3 Units     unitless
+# TableCol  4 ColHeader Volume_mm3
+# TableCol  4 FieldName Volume
+# TableCol  4 Units     mm^3
+# TableCol  5 ColHeader StructName
+# TableCol  5 FieldName Structure Name
+# TableCol  5 Units     NA
+# TableCol  6 ColHeader normMean 
+# TableCol  6 FieldName Intensity normMean
+# TableCol  6 Units     MR
+# TableCol  7 ColHeader normStdDev
+# TableCol  7 FieldName Itensity normStdDev
+# TableCol  7 Units     MR
+# TableCol  8 ColHeader normMin
+# TableCol  8 FieldName Intensity normMin
+# TableCol  8 Units     MR
+# TableCol  9 ColHeader normMax
+# TableCol  9 FieldName Intensity normMax
+# TableCol  9 Units     MR
+# TableCol 10 ColHeader normRange
+# TableCol 10 FieldName Intensity normRange
+# TableCol 10 Units     MR
+# NRows 70 
+# NTableCols 10 
+# ColHeaders  Index SegId NVoxels Volume_mm3 StructName normMean normStdDev normMin normMax normRange  
+  1 3001      2601     2512.0  wm-lh-bankssts                    97.0035     9.7451    68.0000   114.0000    46.0000 
+  2 3002      2569     2546.1  wm-lh-caudalanteriorcingulate    101.8139     8.1896    74.0000   119.0000    45.0000 
+  3 3003      7450     7223.8  wm-lh-caudalmiddlefrontal         94.9421    10.7322    65.0000   114.0000    49.0000 
+  4 3005      3369     3259.8  wm-lh-cuneus                      94.9332    10.4060    69.0000   117.0000    48.0000 
+  5 3006       812      861.8  wm-lh-entorhinal                  80.1010     8.2502    50.0000   106.0000    56.0000 
+  6 3007      5824     5518.4  wm-lh-fusiform                    88.3800    11.4213    37.0000   114.0000    77.0000 
+  7 3008      9490     9347.7  wm-lh-inferiorparietal            97.8016    11.3678    67.0000   120.0000    53.0000 
+  8 3009      6336     6183.9  wm-lh-inferiortemporal            87.1286    12.3249    46.0000   115.0000    69.0000 
+  9 3010      3865     3816.4  wm-lh-isthmuscingulate           100.3868     8.7188    48.0000   115.0000    67.0000 
+ 10 3011     11004    10674.5  wm-lh-lateraloccipital            88.3762    11.5626    60.0000   113.0000    53.0000 
+ 11 3012      7085     6924.7  wm-lh-lateralorbitofrontal        93.0385    10.5048    65.0000   111.0000    46.0000 
+ 12 3013      6295     6109.3  wm-lh-lingual                     88.7207    11.9893    33.0000   116.0000    83.0000 
+ 13 3014      4042     3921.5  wm-lh-medialorbitofrontal         88.1319    11.2105    28.0000   110.0000    82.0000 
+ 14 3015      4263     4162.3  wm-lh-middletemporal              82.0263    10.3133    60.0000   113.0000    53.0000 
+ 15 3016      1488     1537.2  wm-lh-parahippocampal             89.2776     8.3251    65.0000   111.0000    46.0000 
+ 16 3017      4833     4766.4  wm-lh-paracentral                 96.0341     8.7242    70.0000   112.0000    42.0000 
+ 17 3018      4449     4318.2  wm-lh-parsopercularis             97.8932    11.9277    66.0000   121.0000    55.0000 
+ 18 3019      1013     1021.9  wm-lh-parsorbitalis               86.1244    10.0806    66.0000   112.0000    46.0000 
+ 19 3020      3476     3438.2  wm-lh-parstriangularis            93.2221    11.4279    65.0000   116.0000    51.0000 
+ 20 3021      4297     3997.9  wm-lh-pericalcarine               92.4010    10.9981    64.0000   115.0000    51.0000 
+ 21 3022      8914     8713.7  wm-lh-postcentral                 90.4774    11.1922    64.0000   120.0000    56.0000 
+ 22 3023      4922     4771.9  wm-lh-posteriorcingulate          99.0494     9.6038    40.0000   120.0000    80.0000 
+ 23 3024     15816    15460.2  wm-lh-precentral                  93.3146    10.5833    63.0000   123.0000    60.0000 
+ 24 3025      9693     9512.1  wm-lh-precuneus                  101.0122    10.4053    34.0000   123.0000    89.0000 
+ 25 3026      2855     2721.7  wm-lh-rostralanteriorcingulate    94.9534    11.9133    34.0000   124.0000    90.0000 
+ 26 3027     13505    13250.9  wm-lh-rostralmiddlefrontal        95.2532    10.9045    66.0000   119.0000    53.0000 
+ 27 3028     21614    21321.0  wm-lh-superiorfrontal             94.7018     9.7207    67.0000   112.0000    45.0000 
+ 28 3029     11851    11705.4  wm-lh-superiorparietal            98.2010    10.5361    66.0000   118.0000    52.0000 
+ 29 3030      8058     8129.2  wm-lh-superiortemporal            91.7812    12.2055    63.0000   115.0000    52.0000 
+ 30 3031      9710     9452.1  wm-lh-supramarginal               95.3726    12.1487    65.0000   125.0000    60.0000 
+ 31 3032       359      364.5  wm-lh-frontalpole                 90.1643     9.6661    68.0000   109.0000    41.0000 
+ 32 3033       760      802.4  wm-lh-temporalpole                77.0237     9.3545    60.0000   101.0000    41.0000 
+ 33 3034       767      739.9  wm-lh-transversetemporal          91.7301     8.4409    72.0000   109.0000    37.0000 
+ 34 3035      9915     9690.0  wm-lh-insula                      95.9767    10.7506    35.0000   123.0000    88.0000 
+ 35 4001      2477     2401.1  wm-rh-bankssts                    97.5902    10.3221    67.0000   115.0000    48.0000 
+ 36 4002      2978     2936.1  wm-rh-caudalanteriorcingulate    101.4993     8.7541    73.0000   115.0000    42.0000 
+ 37 4003      6672     6445.6  wm-rh-caudalmiddlefrontal         94.9323    11.6110    66.0000   114.0000    48.0000 
+ 38 4005      3358     3218.5  wm-rh-cuneus                      92.9506     9.8817    66.0000   115.0000    49.0000 
+ 39 4006       575      617.5  wm-rh-entorhinal                  79.6104     8.6196    26.0000   103.0000    77.0000 
+ 40 4007      5446     5253.8  wm-rh-fusiform                    90.3671    11.7024    48.0000   116.0000    68.0000 
+ 41 4008     12476    12185.4  wm-rh-inferiorparietal            96.6652    12.2178    65.0000   120.0000    55.0000 
+ 42 4009      5183     5045.3  wm-rh-inferiortemporal            87.3704    11.9947    62.0000   114.0000    52.0000 
+ 43 4010      3589     3570.8  wm-rh-isthmuscingulate            99.5138     8.6139    62.0000   115.0000    53.0000 
+ 44 4011     10090     9880.6  wm-rh-lateraloccipital            89.2856    12.2495    59.0000   117.0000    58.0000 
+ 45 4012      7123     6954.3  wm-rh-lateralorbitofrontal        90.4810    10.7228    59.0000   121.0000    62.0000 
+ 46 4013      7628     7390.5  wm-rh-lingual                     90.9744    12.0386    41.0000   119.0000    78.0000 
+ 47 4014      4796     4797.5  wm-rh-medialorbitofrontal         91.9018    11.5839    33.0000   114.0000    81.0000 
+ 48 4015      5526     5409.9  wm-rh-middletemporal              84.8498    12.3874    61.0000   114.0000    53.0000 
+ 49 4016      1530     1585.4  wm-rh-parahippocampal             88.8752     8.7194    63.0000   112.0000    49.0000 
+ 50 4017      4810     4777.9  wm-rh-paracentral                 96.4100     8.0507    68.0000   113.0000    45.0000 
+ 51 4018      3987     3883.2  wm-rh-parsopercularis             96.6850    11.3934    67.0000   122.0000    55.0000 
+ 52 4019      1402     1407.7  wm-rh-parsorbitalis               85.9544     9.8816    65.0000   108.0000    43.0000 
+ 53 4020      3854     3755.4  wm-rh-parstriangularis            92.6925    10.3468    68.0000   113.0000    45.0000 
+ 54 4021      4223     3869.1  wm-rh-pericalcarine               90.5816    10.6563    63.0000   114.0000    51.0000 
+ 55 4022      8399     8231.8  wm-rh-postcentral                 89.8393    11.6256    64.0000   122.0000    58.0000 
+ 56 4023      4588     4445.1  wm-rh-posteriorcingulate          97.7411     9.3550    50.0000   116.0000    66.0000 
+ 57 4024     15235    14898.2  wm-rh-precentral                  92.2593    10.6239    64.0000   119.0000    55.0000 
+ 58 4025     10761    10524.1  wm-rh-precuneus                   99.7908    10.6824    67.0000   119.0000    52.0000 
+ 59 4026      1877     1817.0  wm-rh-rostralanteriorcingulate    95.3676     9.9165    71.0000   116.0000    45.0000 
+ 60 4027     12977    12701.9  wm-rh-rostralmiddlefrontal        94.7818    11.0499    66.0000   115.0000    49.0000 
+ 61 4028     17902    17618.1  wm-rh-superiorfrontal             94.4570    10.4738    65.0000   114.0000    49.0000 
+ 62 4029     11361    11202.5  wm-rh-superiorparietal            95.0116    11.2582    65.0000   119.0000    54.0000 
+ 63 4030      7064     7065.3  wm-rh-superiortemporal            90.3657    12.2806    61.0000   143.0000    82.0000 
+ 64 4031      9127     8863.9  wm-rh-supramarginal               95.2955    12.7435    63.0000   119.0000    56.0000 
+ 65 4032       501      514.3  wm-rh-frontalpole                 92.9281     9.9839    73.0000   115.0000    42.0000 
+ 66 4033       756      780.1  wm-rh-temporalpole                77.0952     7.9339    61.0000   102.0000    41.0000 
+ 67 4034       510      475.5  wm-rh-transversetemporal          91.9157     8.9136    70.0000   124.0000    54.0000 
+ 68 4035      9430     9250.4  wm-rh-insula                      95.7054    10.6164    66.0000   129.0000    63.0000 
+ 69 5001     35796    36106.6  Left-UnsegmentedWhiteMatter      100.5774    11.3327    22.0000   128.0000   106.0000 
+ 70 5002     34191    34670.3  Right-UnsegmentedWhiteMatter     101.1939     9.5786    35.0000   122.0000    87.0000 


### PR DESCRIPTION
This module was failing on my freesurfer output - as there is a non-Meausre line (`# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3`) mixed inside a list of Measures 

```
# SUBJECTS_DIR /N/dc2/scratch/hayashis/bigred3-workflows/5eb0689676c10ead933d673c/5eb068b076c10e7b013d673f
# anatomy_type surface
# subjectname output
# hemi lh
# AnnotationFile ../label/lh.aparc.annot
# AnnotationFileTimeStamp 2020/05/04 21:58:14
# Measure Cortex, NumVert, Number of Vertices, 118968, unitless
# Measure Cortex, WhiteSurfArea, White Surface Total Area, 84858.5, mm^2
# Measure Cortex, MeanThickness, Mean Thickness, 2.39891, mm
# BrainVolStatsFixed-NotNeeded because voxelvolume=1mm3
# Measure BrainSeg, BrainSegVol, Brain Segmentation Volume, 1169408.000000, mm^3
# Measure BrainSegNotVent, BrainSegVolNotVent, Brain Segmentation Volume Without Ventricles, 1157593.000000, mm^3
# Measure BrainSegNotVentSurf, BrainSegVolNotVentSurf, Brain Segmentation Volume Without Ventricles from Surf, 1157593.000000, mm^3
# Measure Cortex, CortexVol, Total cortical gray matter volume, 454587.696158, mm^3
# Measure SupraTentorial, SupraTentorialVol, Supratentorial volume, 1023873.000000, mm^3
# Measure SupraTentorialNotVent, SupraTentorialVolNotVent, Supratentorial volume, 1012058.000000, mm^3
# Measure EstimatedTotalIntraCranialVol, eTIV, Estimated Total Intracranial Volume, 1420434.160521, mm^3
# NTableCols 10
# TableCol  1 ColHeader StructName
# TableCol  1 FieldName Structure Name
```

The patch simply check to see if there is valid regex match and if not skip the line.