### PR TITLE
adapt to breaking change in pandas v1.2.0 making `get_filepath_or_buffer` private without major release (semver!?)

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -46,12 +46,15 @@ jobs:
         - 0.23.*
         - 0.24.*
         - 0.25.*
-        - 1.1.*
+        - 1.1.* # pandas.io.common.get_handle does not yet support urls
+        - 1.*
         exclude:
           # https://travis-ci.org/github/fphammerle/freesurfer-stats/jobs/683777317#L208
           # https://github.com/pandas-dev/pandas/commit/18efcb27361478daa3118079ecb166c733691ecb#diff-2eeaed663bd0d25b7e608891384b7298R814
         - python-version: 3.5
           pandas-version: 1.1.*
+        - python-version: 3.5
+          pandas-version: 1.*
         - python-version: 3.7
           pandas-version: 0.21.*
         - python-version: 3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `AttributeError` when using pandas v1.2.0
 
 ## [1.2.0] - 2020-05-30
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -68,12 +68,8 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "numpy<2",
-        # pandas v1.2.0 made `get_filepath_or_buffer` private without releasing major version.
-        # semver?!? not even mentioned in changelog
-        # https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.2.0.html
-        # https://github.com/pandas-dev/pandas/commit/6d1541e1782a7b94797d5432922e64a97934cfa4#diff-934d8564d648e7521db673c6399dcac98e45adfd5230ba47d3aabfcc21979febL247
-        # TODO verify lower version constraint
-        "pandas>=0.21,<1.2",
+        # still hoping that pandas will stick to semantic versioning in the future
+        "pandas>=0.21,<2",
     ],
     setup_requires=["setuptools_scm"],
     tests_require=["pytest<5"],


### PR DESCRIPTION
https://github.com/pandas-dev/pandas/pull/37639
https://github.com/pandas-dev/pandas/commit/6d1541e1782a7b94797d5432922e64a97934cfa4#diff-934d8564d648e7521db673c6399dcac98e45adfd5230ba47d3aabfcc21979febL247